### PR TITLE
Update mongodb-atlas-project.json

### DIFF
--- a/cfn-resources/project/mongodb-atlas-project.json
+++ b/cfn-resources/project/mongodb-atlas-project.json
@@ -45,7 +45,7 @@
     },
     "additionalProperties": false,
     "required": [
-        "Properties",
+        "Name",
         "OrgId"
     ],
     "readOnlyProperties": [


### PR DESCRIPTION
When we try to deploy project on our AWS account, the stack has been failed with "Properties" not found error message for project. The problem is "properties" and "orgid" fields are mandatory on project creation and "properties" does not exists in property list. We can use "name" instead of that.

