### PR TITLE
updated region tag

### DIFF
--- a/cfn-resources/trigger/cmd/resource/resource.go
+++ b/cfn-resources/trigger/cmd/resource/resource.go
@@ -320,6 +320,6 @@ type AWSEVENTB struct {
 
 type AWSConf struct {
 	AccountID           *string `json:"account_id,omitempty"`
-	Region              *string `json:",omitempty"`
+	Region              *string `json:"region,omitempty"`
 	ExtendedJSONEnabled *bool   `json:"extended_json_enabled,omitempty"`
 }


### PR DESCRIPTION
The go-client right now doesn't has typed params for trigger creation. Instead uses a map. The tags are required to correctly map fields to the request. `region` tag was missing from the request body

- [ *] Bug fix (non-breaking change which fixes an issue)


## Required Checklist:

- [*] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [*] I have added tests that prove my fix is effective or that my feature works
- [*] I have added any necessary documentation (if appropriate)
- [*] I have run `make fmt` and formatted my code

## Further comments

