### PR TITLE
INTMDB-566: Enable MONGODB_ATLAS_OPS_MANAGER_URL for all the CFN resources

### DIFF
--- a/cfn-resources/alert-configuration/template.yml
+++ b/cfn-resources/alert-configuration/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/auditing/template.yml
+++ b/cfn-resources/auditing/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-backup-restore-jobs/template.yml
+++ b/cfn-resources/cloud-backup-restore-jobs/template.yml
@@ -20,4 +20,8 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-
+      Environment:
+        Variables:
+          MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/cloud-backup-schedule/template.yml
+++ b/cfn-resources/cloud-backup-schedule/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-backup-snapshot-export-bucket/template.yml
+++ b/cfn-resources/cloud-backup-snapshot-export-bucket/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-backup-snapshot-export-job/template.yml
+++ b/cfn-resources/cloud-backup-snapshot-export-job/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-backup-snapshot/template.yml
+++ b/cfn-resources/cloud-backup-snapshot/template.yml
@@ -22,4 +22,8 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-
+      Environment:
+        Variables:
+          MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/cloud-provider-access/template.yml
+++ b/cfn-resources/cloud-provider-access/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-provider-snapshot-restore-jobs/template.yml
+++ b/cfn-resources/cloud-provider-snapshot-restore-jobs/template.yml
@@ -20,4 +20,8 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-
+      Environment:
+        Variables:
+          MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/cloud-provider-snapshots/template.yml
+++ b/cfn-resources/cloud-provider-snapshots/template.yml
@@ -20,4 +20,8 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-
+      Environment:
+        Variables:
+          MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/cluster/template.yml
+++ b/cfn-resources/cluster/template.yml
@@ -20,7 +20,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/custom-db-role/template.yml
+++ b/cfn-resources/custom-db-role/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/custom-dns-configuration-cluster-aws/template.yml
+++ b/cfn-resources/custom-dns-configuration-cluster-aws/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/database-user/template.yml
+++ b/cfn-resources/database-user/template.yml
@@ -20,4 +20,8 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-
+      Environment:
+        Variables:
+          MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/datalakes/template.yml
+++ b/cfn-resources/datalakes/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/encryption-at-rest/template.yml
+++ b/cfn-resources/encryption-at-rest/template.yml
@@ -20,4 +20,8 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-
+      Environment:
+        Variables:
+          MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/federated-setting-org-configs/template.yml
+++ b/cfn-resources/federated-setting-org-configs/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/federated-settings-identity-provider/template.yml
+++ b/cfn-resources/federated-settings-identity-provider/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/federated-settings-org-role-mapping/template.yml
+++ b/cfn-resources/federated-settings-org-role-mapping/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/global-cluster-config/template.yml
+++ b/cfn-resources/global-cluster-config/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/ldap-configuration/template.yml
+++ b/cfn-resources/ldap-configuration/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/ldap-verify/template.yml
+++ b/cfn-resources/ldap-verify/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/legacy-cluster/template.yml
+++ b/cfn-resources/legacy-cluster/template.yml
@@ -20,7 +20,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/maintenance-window/template.yml
+++ b/cfn-resources/maintenance-window/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/network-container/template.yml
+++ b/cfn-resources/network-container/template.yml
@@ -20,4 +20,8 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-
+      Environment:
+        Variables:
+          MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/network-peering/template.yml
+++ b/cfn-resources/network-peering/template.yml
@@ -20,4 +20,8 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-
+      Environment:
+        Variables:
+          MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/online-archive/template.yml
+++ b/cfn-resources/online-archive/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/org-invitation/template.yml
+++ b/cfn-resources/org-invitation/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/private-endpoint-adl/template.yml
+++ b/cfn-resources/private-endpoint-adl/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/private-endpoint-regional-mode/template.yml
+++ b/cfn-resources/private-endpoint-regional-mode/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/private-endpoint/template.yml
+++ b/cfn-resources/private-endpoint/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/project-invitation/template.yml
+++ b/cfn-resources/project-invitation/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/project-ip-access-list/template.yml
+++ b/cfn-resources/project-ip-access-list/template.yml
@@ -21,7 +21,9 @@ Resources:
       Handler: handler
       Runtime: go1.x
       CodeUri: bin/
-      Environment: 
-        Variables: 
+      Environment:
+        Variables:
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/project/template.yml
+++ b/cfn-resources/project/template.yml
@@ -22,5 +22,7 @@ Resources:
       CodeUri: bin/
       Environment:
         Variables:
+          MODE: Test
+          LOG_LEVEL: debug
           MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/search-index/template.yml
+++ b/cfn-resources/search-index/template.yml
@@ -29,4 +29,4 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/serverless-instance/template.yml
+++ b/cfn-resources/serverless-instance/template.yml
@@ -24,4 +24,6 @@ Resources:
       Environment: 
         Variables: 
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/teams/template.yml
+++ b/cfn-resources/teams/template.yml
@@ -24,4 +24,6 @@ Resources:
       Environment: 
         Variables: 
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/third-party-integration/template.yml
+++ b/cfn-resources/third-party-integration/template.yml
@@ -24,4 +24,6 @@ Resources:
       Environment: 
         Variables: 
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/trigger/template.yml
+++ b/cfn-resources/trigger/template.yml
@@ -24,4 +24,6 @@ Resources:
       Environment: 
         Variables: 
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/x509-authentication-database-user/template.yml
+++ b/cfn-resources/x509-authentication-database-user/template.yml
@@ -24,4 +24,6 @@ Resources:
       Environment: 
         Variables: 
           MODE: Test
+          LOG_LEVEL: debug
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 


### PR DESCRIPTION
## Description

[#208](https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/208) enables `MONGODB_ATLAS_OPS_MANAGER_URL` for the project resource. This PR enables this env variable for all the CFN resources.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

