### PR TITLE
Updated gitActions to run only on pull request and not push

### DIFF
--- a/.github/workflows/check-copyright.yml
+++ b/.github/workflows/check-copyright.yml
@@ -1,9 +1,9 @@
 name: check-copyright
 on:
   push:
-    branches: [ "master" , "INT**"]
+    branches:
+      - master
   pull_request:
-    branches: [ "master", "INT**" ]
 jobs:
   check-copyright:
     runs-on: ubuntu-latest

--- a/.github/workflows/gobuild.yml
+++ b/.github/workflows/gobuild.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "master" , "INT**"]
+    branches:
+      - master
   pull_request:
-    branches: [ "master", "INT**" ]
 
 jobs:
 

--- a/.github/workflows/golint.yml
+++ b/.github/workflows/golint.yml
@@ -1,9 +1,9 @@
 name: golangci-lint
 on:
   push:
-    branches: [ "master" , "INT**"]
+    branches:
+      - master
   pull_request:
-    branches: [ "master", "INT**" ]
 jobs:
   lint-go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
Updated gitActions to run only on pull requests + master and not push

**Before:**
![Screenshot 2023-02-08 at 11 16 41](https://user-images.githubusercontent.com/5663078/217515008-7c0a08df-5aaf-47fa-b382-2ace1454cefe.png)

**After:**
![Screenshot 2023-02-08 at 11 17 33](https://user-images.githubusercontent.com/5663078/217515192-446806ab-fe05-4ae3-b7ca-9f014a235bac.png)

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

