### PR TITLE
INTMDB-578: add ProjectId to PrimaryIdentifier for ThirdPartyIntegration CFN

### DIFF
--- a/cfn-resources/third-party-integration/mongodb-atlas-thirdpartyintegration.json
+++ b/cfn-resources/third-party-integration/mongodb-atlas-thirdpartyintegration.json
@@ -33,6 +33,7 @@
         }
     },
     "primaryIdentifier": [
+        "/properties/ProjectId",
         "/properties/Type"
     ],
     "writeOnlyProperties": [


### PR DESCRIPTION


## Description

The ThirdPartyIntegration CFN currently uses only “Type” as the primaryIdentifier. This would mean we can’t create same type of integrations for different projects from the same stack.
As a fix, we are adding ProjectId to the PrimaryIdentifier for this resource in addition to "(Integration)Type"

Testing:
Ran tests locally against Atlas account and project:
<img width="1504" alt="Screenshot 2023-02-13 at 17 14 42" src="https://user-images.githubusercontent.com/122359335/218532215-4e6901a2-fe86-48d0-b5f2-9379b3f7800e.png">




Link to any related issue(s): 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments

