### PR TITLE
INTMDB-583: Update cdk.sh to create L2 and L3 CDK project as well

### DIFF
--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -86,7 +86,6 @@ if [ "$cdk_type" = "L2" ]; then
   rm -rf .git
 
   popd
-  exit 0
 fi
 
 if [ "$cdk_type" = "L3" ]; then
@@ -98,7 +97,6 @@ if [ "$cdk_type" = "L3" ]; then
   rm -rf .git
 
   popd
-  exit 0
 fi
 
 

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -17,7 +17,8 @@
 
 # This shell script can be use to generate one L1 | L2 | L3 CDK Construct.
 # In case of L1 constructor, the script uses the CFN template to generate the CDK resource.
-# How to execute:
+#
+# How to use it:
 #   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
 #   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
 #   2. CDK L2:  ./cdk/sh "<RESOURCE NAME>" L2

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -75,28 +75,28 @@ cdk_type=$(echo "$2" | tr '[:upper:]' '[:lower:]')
 
 if [[ -z "${cdk_type}" || "${cdk_type}" = "l1" ]]; then # Generate L1 CDK constructor
 	echo "Generating L1 CDK resource"
-	dir="../cfn-resources/$resource"
-	for file in "$dir"/mongodb-atlas-*.json; do
+	dir="../cfn-resources/${resource}"
+	for file in "${dir}"/mongodb-atlas-*.json; do
 		if [[ -f $file ]]; then
-			src=$(jq -r '.typeName' "$file")
+			src=$(jq -r '.typeName' "${file}")
 			echo "generating for $src"
-			path=$(basename "$dir")
+			path=$(basename "${dir}")
 			index_exists=false
 			if [ -f cdk-resources/"${path}"/src/index.ts ]; then
 				rm -rf cdk-resources/"${path}"/src/*.ts
 				index_exists=true
 			fi
 
-			cdk-import cfn -l typescript -s "$file" -o cdk-resources/"${path}"/src "$src"
+			cdk-import cfn -l typescript -s "${file}" -o "cdk-resources/${path}/src" "${src}"
 			# need rename resource file to index.ts file
-			mv "cdk-resources"/"${path}"/"src"/"mongodb-atlas-""${path//-/}".ts cdk-resources/"${path}"/src/index.ts
-			if [ "$index_exists" = true ]; then
+			mv "cdk-resources/${path}/src/mongodb-atlas-${path//-/}.ts" "cdk-resources/${path}/src/index.ts"
+			if [ "${index_exists}" = true ]; then
 				continue
 			fi
 
-			_run_projen_aws_cdk_construct "${resource}" "$path"
+			_run_projen_aws_cdk_construct "${resource}" "${path}"
 		fi
 	done
 else
-	_run_projen_aws_cdk_construct "${resource}" "$cdk_type" # Generate L2 or L3 CDK constructor
+	_run_projen_aws_cdk_construct "${resource}" "${cdk_type}" # Generate L2 or L3 CDK constructor
 fi

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -27,10 +27,10 @@ set -euo pipefail
 
 
 _print_usage() {
-	echo
-	echo 'Usage:'
-	echo './cdk.sh   "<RESOURCE NAME>" "<L1|L2|L3>"'
-	echo
+  echo
+  echo 'Usage:'
+  echo './cdk.sh   "<RESOURCE NAME>" "<L1|L2|L3>"'
+  echo
   echo 'Example:'
   echo './cdk.sh cluster L1'
   echo

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -28,23 +28,26 @@ set -euo pipefail
 
 _print_usage() {
 	echo
-	echo '  ./cdk.sh   "< RESOURCE NAME >" "< L1 | L2 | L3 >"'
-  echo 'Example: ./cdk.sh cluster L1'
+  echo 'Usage:'
+	echo './cdk.sh   "<RESOURCE NAME>" "<L1|L2|L3>"'
+  echo
+  echo 'Example:'
+  echo './cdk.sh cluster L1'
+  echo
 }
 
 
-
-resource=$1
-cdk_type=$(echo "$2" | tr '[:lower:]' '[:upper:]')
-
-if [[ -z "${resource}" || -z "${cdk_type}" ]]; then
+if [ "$#" -ne 2 ]; then
     echo "Error: please provide the resource name and the type of CDK constructor"
     _print_usage
     exit 1
 fi
 
+resource=$1
+cdk_type=$(echo "$2" | tr '[:lower:]' '[:upper:]')
 
-if [ -z "${cdk_type}" || "$cdk_type" = "L1" ]; then
+
+if [[ -z "${cdk_type}" || "${cdk_type}" = "L1" ]]; then
   echo "Generating L1 CDK resource"
   dir="../cfn-resources/$resource"
   for file in "$dir"/mongodb-atlas-*.json;
@@ -53,7 +56,6 @@ if [ -z "${cdk_type}" || "$cdk_type" = "L1" ]; then
             src=$( jq -r '.typeName' "$file" )
             echo "generating for $src"
             path=$(basename "$dir")
-            echo "$path"
             index_exists=false
             if [ -f cdk-resources/"${path}"/src/index.ts ]; then
                 rm -rf cdk-resources/"${path}"/src/*.ts
@@ -77,26 +79,26 @@ fi
 
 if [ "$cdk_type" = "L2" ]; then
   echo "Generating L2 CDK resource"
+  mkdir "l2-cdk-resources/${resource}"
+  pushd "l2-cdk-resources/${resource}"
 
-  mkdir "l2-cdk-resources${path}"
-  pushd "l2-cdk-resources${path}"
-
-  npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk-l2/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l2','mongodb','atlas',"$path"}
+  npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-l2/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l2','mongodb','atlas',"$resource"}
   rm -rf .git
 
   popd
+  exit 0
 fi
 
 if [ "$cdk_type" = "L3" ]; then
   echo "Generating L3 CDK resource"
-  
-  mkdir "l3-cdk-resources${path}"
-  pushd "l3-cdk-resources${path}"
-  
-  npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk-l3/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l3','mongodb','atlas',"$path"}
+  mkdir "l3-cdk-resources/${resource}"
+  pushd "l3-cdk-resources/${resource}"
+
+  npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-l3/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l3','mongodb','atlas',"$resource"}
   rm -rf .git
-  
+
   popd
+  exit 0
 fi
 
 

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -94,7 +94,7 @@ if [[ -z "${cdk_type}" || "${cdk_type}" = "l1" ]]; then # Generate L1 CDK constr
 				continue
 			fi
 
-			_run_projen_aws_cdk_construct "${resource}" "${path}"
+			_run_projen_aws_cdk_construct "${path}" "${cdk_type}"
 		fi
 	done
 else

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # This shell script can be use to generate one L1 | L2 | L3 CDK Construct.
 # In case of L1 constructor, the script uses the CFN template to generate the CDK resource.
 #
@@ -25,78 +24,72 @@
 
 set -euo pipefail
 
-
 _print_usage() {
-  echo
-  echo 'Usage:'
-  echo './cdk.sh   "<RESOURCE NAME>" "<L1|L2|L3>"'
-  echo
-  echo 'Example:'
-  echo './cdk.sh cluster L1'
-  echo
+	echo
+	echo 'Usage:'
+	echo './cdk.sh   "<RESOURCE NAME>" "<L1|L2|L3>"'
+	echo
+	echo 'Example:'
+	echo './cdk.sh cluster L1'
+	echo
 }
 
-
 if [ "$#" -ne 2 ]; then
-    echo "Error: please provide the resource name and the type of CDK constructor"
-    _print_usage
-    exit 1
+	echo "Error: please provide the resource name and the type of CDK constructor"
+	_print_usage
+	exit 1
 fi
 
 resource=$1
 cdk_type=$(echo "$2" | tr '[:lower:]' '[:upper:]')
 
-
 if [[ -z "${cdk_type}" || "${cdk_type}" = "L1" ]]; then
-  echo "Generating L1 CDK resource"
-  dir="../cfn-resources/$resource"
-  for file in "$dir"/mongodb-atlas-*.json;
-      do
-          if [[ -f $file ]]; then
-            src=$( jq -r '.typeName' "$file" )
-            echo "generating for $src"
-            path=$(basename "$dir")
-            index_exists=false
-            if [ -f cdk-resources/"${path}"/src/index.ts ]; then
-                rm -rf cdk-resources/"${path}"/src/*.ts
-                index_exists=true
-            fi
+	echo "Generating L1 CDK resource"
+	dir="../cfn-resources/$resource"
+	for file in "$dir"/mongodb-atlas-*.json; do
+		if [[ -f $file ]]; then
+			src=$(jq -r '.typeName' "$file")
+			echo "generating for $src"
+			path=$(basename "$dir")
+			index_exists=false
+			if [ -f cdk-resources/"${path}"/src/index.ts ]; then
+				rm -rf cdk-resources/"${path}"/src/*.ts
+				index_exists=true
+			fi
 
-            cdk-import cfn -l typescript -s "$file" -o cdk-resources/"${path}"/src "$src"
-            # need rename resource file to index.ts file
-            mv "cdk-resources"/"${path}"/"src"/"mongodb-atlas-""${path//-}".ts cdk-resources/"${path}"/src/index.ts
-            if [ "$index_exists" = true ] ; then
-              continue
-            fi
-            
-            pushd "cdk-resources/${path}" || exit
-            npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l1','mongodb','atlas',"$path"}
-            rm -rf .git
-            popd
-          fi
-      done
+			cdk-import cfn -l typescript -s "$file" -o cdk-resources/"${path}"/src "$src"
+			# need rename resource file to index.ts file
+			mv "cdk-resources"/"${path}"/"src"/"mongodb-atlas-""${path//-/}".ts cdk-resources/"${path}"/src/index.ts
+			if [ "$index_exists" = true ]; then
+				continue
+			fi
+
+			pushd "cdk-resources/${path}" || exit
+			npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l1','mongodb','atlas',"$path"}
+			rm -rf .git
+			popd
+		fi
+	done
 fi
 
 if [ "$cdk_type" = "L2" ]; then
-  echo "Generating L2 CDK resource"
-  mkdir "l2-cdk-resources/${resource}"
-  pushd "l2-cdk-resources/${resource}"
+	echo "Generating L2 CDK resource"
+	mkdir "l2-cdk-resources/${resource}"
+	pushd "l2-cdk-resources/${resource}"
 
-  npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-l2/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l2','mongodb','atlas',"$resource"}
-  rm -rf .git
+	npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-l2/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l2','mongodb','atlas',"$resource"}
+	rm -rf .git
 
-  popd
+	popd
 fi
 
 if [ "$cdk_type" = "L3" ]; then
-  echo "Generating L3 CDK resource"
-  mkdir "l3-cdk-resources/${resource}"
-  pushd "l3-cdk-resources/${resource}"
+	echo "Generating L3 CDK resource"
+	mkdir "l3-cdk-resources/${resource}"
+	pushd "l3-cdk-resources/${resource}"
 
-  npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-l3/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l3','mongodb','atlas',"$resource"}
-  rm -rf .git
+	npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-l3/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l3','mongodb','atlas',"$resource"}
+	rm -rf .git
 
-  popd
+	popd
 fi
-
-

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
+
 # This shell script can be use to generate one L1 | L2 | L3 CDK Construct.
 # In case of L1 constructor, the script uses the CFN template to generate the CDK resource.
 # How to execute:

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -34,7 +34,7 @@ _print_usage() {
 	echo
 }
 
-_run_projen_awscdk-construct() {
+_run_projen_aws_cdk_construct() {
 	if [ "$#" -ne 2 ]; then
 		echo "Error: please provide the resource name and the cdk type"
 		echo
@@ -94,9 +94,9 @@ if [[ -z "${cdk_type}" || "${cdk_type}" = "l1" ]]; then # Generate L1 CDK constr
 				continue
 			fi
 
-			_run_projen_awscdk-construct() "${resource}" "$path"
+			_run_projen_aws_cdk_construct "${resource}" "$path"
 		fi
 	done
 else
-	_run_projen_awscdk-construct() "${resource}" "$cdk_type" # Generate L2 or L3 CDK constructor
+	_run_projen_aws_cdk_construct "${resource}" "$cdk_type" # Generate L2 or L3 CDK constructor
 fi

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -1,56 +1,102 @@
 #!/bin/bash
-# This shell script can be use to generate one or multiple L1 Constrcuts from CFN resources.
-# How to execute:
-#   1. For all resources without arguments :  ./cdk.sh
-#   2. For specific resource with argument :  ./cdk/sh "<RESOURCE NAME>"
-#                            For example   :  ./cdk/sh "auditing"  or  ./cdk/sh "cluster"
-#
-#   3. We can run it for multiple resources, let's say we are creating for "auditing", "cluster" and  "database-user"
-#      then we can pass resource name with space separated.
-#                                          : ./cdk/sh "<RESOURCE NAME> <RESOURCE NAME> <RESOURCE NAME>"
-#                            For example   : ./cdk.sh "auditing cluster database-user"
-#
-#   In this way we can run it for one or multiple resources
 
-resources=$1
-if [[ -n "$resources" ]];
-then
-  source_dir=${resources};
-else
-  echo "Generating for all resources."
-  source_dir='*';
-  dir="../cfn-resources/$source_dir"
+# Copyright 2023 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+# This shell script can be use to generate one L1 | L2 | L3 CDK Construct.
+# In case of L1 constructor, the script uses the CFN template to generate the CDK resource.
+# How to execute:
+#   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
+#   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
+#   2. CDK L2:  ./cdk/sh "<RESOURCE NAME>" L2
+#   4. CDK L3:  ./cdk/sh "<RESOURCE NAME>" L3
+
+set -euo pipefail
+
+
+_print_usage() {
+	echo
+	echo '  ./cdk.sh   "< RESOURCE NAME >" "< L1 | L2 | L3 >"'
+  echo 'Example: ./cdk.sh cluster L1'
+}
+
+
+
+resource=$1
+cdk_type=$(echo "$2" | tr '[:lower:]' '[:upper:]')
+
+if [[ -z "${resource}" || -z "${cdk_type}" ]]; then
+    echo "Error: please provide the resource name and the type of CDK constructor"
+    _print_usage
+    exit 1
 fi
-for resource in ../cfn-resources/$source_dir;
-do
-  # echo $dir
+
+
+if [ -z "${cdk_type}" || "$cdk_type" = "L1" ]; then
+  echo "Generating L1 CDK resource"
   dir="../cfn-resources/$resource"
   for file in "$dir"/mongodb-atlas-*.json;
       do
           if [[ -f $file ]]; then
-            #echo $file
             src=$( jq -r '.typeName' "$file" )
             echo "generating for $src"
-            #mkdir -p cdk/${dir} && cd cdk/${dir}
             path=$(basename "$dir")
             echo "$path"
             index_exists=false
-             if [ -f cdk-resources/"${path}"/src/index.ts ]; then
+            if [ -f cdk-resources/"${path}"/src/index.ts ]; then
                 rm -rf cdk-resources/"${path}"/src/*.ts
                 index_exists=true
-             fi
+            fi
 
             cdk-import cfn -l typescript -s "$file" -o cdk-resources/"${path}"/src "$src"
             # need rename resource file to index.ts file
             mv "cdk-resources"/"${path}"/"src"/"mongodb-atlas-""${path//-}".ts cdk-resources/"${path}"/src/index.ts
             if [ "$index_exists" = true ] ; then
-               continue
+              continue
             fi
-            cd cdk-resources/"${path}" || exit
-            npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'INTMDB-548' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l1','mongodb','atlas',"$path"}
+            
+            pushd "cdk-resources/${path}" || exit
+            npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l1','mongodb','atlas',"$path"}
             rm -rf .git
-            cd ../.. || exit
+            popd
           fi
       done
-done
+fi
+
+if [ "$cdk_type" = "L2" ]; then
+  echo "Generating L2 CDK resource"
+
+  mkdir "l2-cdk-resources${path}"
+  pushd "l2-cdk-resources${path}"
+
+  npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk-l2/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l2','mongodb','atlas',"$path"}
+  rm -rf .git
+
+  popd
+fi
+
+if [ "$cdk_type" = "L3" ]; then
+  echo "Generating L3 CDK resource"
+  
+  mkdir "l3-cdk-resources${path}"
+  pushd "l3-cdk-resources${path}"
+  
+  npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk-l3/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l3','mongodb','atlas',"$path"}
+  rm -rf .git
+  
+  popd
+fi
+
 

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -52,7 +52,7 @@ _run_projen_aws_cdk_construct() {
 		mkdir -p "${dir}"
 	fi
 
-	if [ "$cdk_type" = "l2" ]; then
+	if [ "$cdk_type" = "l3" ]; then
 		echo "Generating L3 CDK resource"
 		dir="l3-cdk-resources/${resource}"
 		mkdir -p "${dir}"

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This shell script can be use to generate one L1 | L2 | L3 CDK Construct.
+# This shell script can be use to generate one l1 | l2 | l3 CDK Construct.
 # In case of L1 constructor, the script uses the CFN template to generate the CDK resource.
 #
 # How to use it:
-#   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
-#   2. CDK L2:  ./cdk/sh "<RESOURCE NAME>" L2
-#   4. CDK L3:  ./cdk/sh "<RESOURCE NAME>" L3
+#   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" l1
+#   2. CDK L2:  ./cdk/sh "<RESOURCE NAME>" l2
+#   4. CDK L3:  ./cdk/sh "<RESOURCE NAME>" l3
 
 set -euo pipefail
 
@@ -30,8 +30,40 @@ _print_usage() {
 	echo './cdk.sh   "<RESOURCE NAME>" "<L1|L2|L3>"'
 	echo
 	echo 'Example:'
-	echo './cdk.sh cluster L1'
+	echo './cdk.sh cluster l1'
 	echo
+}
+
+_run_projen_awscdk-construct(){
+  if [ "$#" -ne 2 ]; then
+	  echo "Error: please provide the resource name and the cdk type"
+    echo 
+    echo "Example: _run_projen_awscdk-construct cluster L2"
+	  exit 1
+  fi
+
+    resource=$1
+    dir="cdk-resources/${resource}"
+    cdk_type=$2
+
+
+    if [ "$cdk_type" = "l2" ]; then
+      echo "Generating L2 CDK resource"
+      dir="l2-cdk-resources/${resource}"
+      mkdir -p "${dir}"
+    fi
+
+    if [ "$cdk_type" = "l2" ]; then
+      echo "Generating L3 CDK resource"
+      dir="l3-cdk-resources/${resource}"
+      mkdir -p "${dir}"
+    fi
+
+
+  	pushd "${dir}"
+    npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-${cdk_type}/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry',"${cdk_type}",'mongodb','atlas',"$resource"}
+    rm -rf .git
+    popd
 }
 
 if [ "$#" -ne 2 ]; then
@@ -41,9 +73,9 @@ if [ "$#" -ne 2 ]; then
 fi
 
 resource=$1
-cdk_type=$(echo "$2" | tr '[:lower:]' '[:upper:]')
+cdk_type=$(echo "$2" | tr '[:upper:]' '[:lower:]')
 
-if [[ -z "${cdk_type}" || "${cdk_type}" = "L1" ]]; then
+if [[ -z "${cdk_type}" || "${cdk_type}" = "l1" ]]; then # Generate L1 CDK constructor
 	echo "Generating L1 CDK resource"
 	dir="../cfn-resources/$resource"
 	for file in "$dir"/mongodb-atlas-*.json; do
@@ -64,32 +96,9 @@ if [[ -z "${cdk_type}" || "${cdk_type}" = "L1" ]]; then
 				continue
 			fi
 
-			pushd "cdk-resources/${path}" || exit
-			npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name '@mongodbatlas-awscdk/'"${path}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description 'Retrieves or creates '"${path}"' in any given Atlas organization' --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l1','mongodb','atlas',"$path"}
-			rm -rf .git
-			popd
+      _run_projen_awscdk-construct() "${resource}" "$path"
 		fi
 	done
-fi
-
-if [ "$cdk_type" = "L2" ]; then
-	echo "Generating L2 CDK resource"
-	mkdir "l2-cdk-resources/${resource}"
-	pushd "l2-cdk-resources/${resource}"
-
-	npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-l2/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l2','mongodb','atlas',"$resource"}
-	rm -rf .git
-
-	popd
-fi
-
-if [ "$cdk_type" = "L3" ]; then
-	echo "Generating L3 CDK resource"
-	mkdir "l3-cdk-resources/${resource}"
-	pushd "l3-cdk-resources/${resource}"
-
-	npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-l3/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry','l3','mongodb','atlas',"$resource"}
-	rm -rf .git
-
-	popd
+else
+  _run_projen_awscdk-construct() "${resource}" "$cdk_type" # Generate L2 or L3 CDK constructor
 fi

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -20,7 +20,6 @@
 #
 # How to use it:
 #   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
-#   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
 #   2. CDK L2:  ./cdk/sh "<RESOURCE NAME>" L2
 #   4. CDK L3:  ./cdk/sh "<RESOURCE NAME>" L3
 
@@ -29,9 +28,9 @@ set -euo pipefail
 
 _print_usage() {
 	echo
-  echo 'Usage:'
+	echo 'Usage:'
 	echo './cdk.sh   "<RESOURCE NAME>" "<L1|L2|L3>"'
-  echo
+	echo
   echo 'Example:'
   echo './cdk.sh cluster L1'
   echo

--- a/cdk/cdk.sh
+++ b/cdk/cdk.sh
@@ -34,36 +34,34 @@ _print_usage() {
 	echo
 }
 
-_run_projen_awscdk-construct(){
-  if [ "$#" -ne 2 ]; then
-	  echo "Error: please provide the resource name and the cdk type"
-    echo 
-    echo "Example: _run_projen_awscdk-construct cluster L2"
-	  exit 1
-  fi
+_run_projen_awscdk-construct() {
+	if [ "$#" -ne 2 ]; then
+		echo "Error: please provide the resource name and the cdk type"
+		echo
+		echo "Example: _run_projen_awscdk-construct cluster L2"
+		exit 1
+	fi
 
-    resource=$1
-    dir="cdk-resources/${resource}"
-    cdk_type=$2
+	resource=$1
+	dir="cdk-resources/${resource}"
+	cdk_type=$2
 
+	if [ "$cdk_type" = "l2" ]; then
+		echo "Generating L2 CDK resource"
+		dir="l2-cdk-resources/${resource}"
+		mkdir -p "${dir}"
+	fi
 
-    if [ "$cdk_type" = "l2" ]; then
-      echo "Generating L2 CDK resource"
-      dir="l2-cdk-resources/${resource}"
-      mkdir -p "${dir}"
-    fi
+	if [ "$cdk_type" = "l2" ]; then
+		echo "Generating L3 CDK resource"
+		dir="l3-cdk-resources/${resource}"
+		mkdir -p "${dir}"
+	fi
 
-    if [ "$cdk_type" = "l2" ]; then
-      echo "Generating L3 CDK resource"
-      dir="l3-cdk-resources/${resource}"
-      mkdir -p "${dir}"
-    fi
-
-
-  	pushd "${dir}"
-    npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-${cdk_type}/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry',"${cdk_type}",'mongodb','atlas',"$resource"}
-    rm -rf .git
-    popd
+	pushd "${dir}"
+	npx projen new awscdk-construct --npm-access "public" --author "MongoDBAtlas" --author-name "MongoDBAtlas" --docgen true --sample-code false --name "@mongodbatlas-awscdk-${cdk_type}/${resource}" --author-address 'https://mongodb.com' --cdk-version '2.1.0' --default-release-branch 'master' --major-version 1 --release-to-npm true --repository-url 'https://github.com/mongodb/mongodbatlas-cloudformation-resources.git' --description "Retrieves or creates ${resource} in any given Atlas organization" --keywords {'cdk','awscdk','aws-cdk','cloudformation','cfn','extensions','constructs','cfn-resources','cloudformation-registry',"${cdk_type}",'mongodb','atlas',"$resource"}
+	rm -rf .git
+	popd
 }
 
 if [ "$#" -ne 2 ]; then
@@ -96,9 +94,9 @@ if [[ -z "${cdk_type}" || "${cdk_type}" = "l1" ]]; then # Generate L1 CDK constr
 				continue
 			fi
 
-      _run_projen_awscdk-construct() "${resource}" "$path"
+			_run_projen_awscdk-construct() "${resource}" "$path"
 		fi
 	done
 else
-  _run_projen_awscdk-construct() "${resource}" "$cdk_type" # Generate L2 or L3 CDK constructor
+	_run_projen_awscdk-construct() "${resource}" "$cdk_type" # Generate L2 or L3 CDK constructor
 fi


### PR DESCRIPTION
## Description

Updated the `cdk.sh` to generate L1, L2 and L3 CDK contractors. 

```bash
# This shell script can be use to generate one L1 | L2 | L3 CDK Construct.
# In case of L1 constructor, the script uses the CFN template to generate the CDK resource.
#
# How to use it:
#   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
#   1. CDK L1:  ./cdk.sh "<RESOURCE NAME>" L1
#   2. CDK L2:  ./cdk/sh "<RESOURCE NAME>" L2
#   4. CDK L3:  ./cdk/sh "<RESOURCE NAME>" L3
```


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

<details>
  <summary>Create L1 CDK constructor</summary>
  
 
```bash
./cdk.sh cluster L1                                                                                                                16.18.0 bazel 5.4.0
Generating L1 CDK resource
generating for MongoDB::Atlas::Cluster
cluster
Unresolvable read-only property (attribute) MongoDB::Atlas::Cluster.ConnectionStrings/Standard
Unresolvable read-only property (attribute) MongoDB::Atlas::Cluster.ConnectionStrings/StandardSrv
Unresolvable read-only property (attribute) MongoDB::Atlas::Cluster.ConnectionStrings/Private
Unresolvable read-only property (attribute) MongoDB::Atlas::Cluster.ConnectionStrings/PrivateSrv
~/workspace/mongodbatlas-cloudformation-resources/cdk/cdk-resources/cluster ~/workspace/mongodbatlas-cloudformation-resources/cdk
👾 Project definition file was created at /Users/andrea.angiolillo/workspace/mongodbatlas-cloudformation-resources/cdk/cdk-resources/cluster/.projenrc.js
yarn install v1.22.19
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
✨  Done in 25.24s.
yarn install v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
✨  Done in 2.81s.

> @mongodbatlas-awscdk/cluster@0.0.0 eslint
> npx projen eslint

Initialized empty Git repository in /Users/andrea.angiolillo/workspace/mongodbatlas-cloudformation-resources/cdk/cdk-resources/cluster/.git/
[main (root-commit) d47118a] chore: project created with projen
 20 files changed, 8977 insertions(+)
 create mode 100644 .eslintrc.json
 create mode 100644 .gitattributes
 create mode 100644 .github/pull_request_template.md
 create mode 100644 .github/workflows/build.yml
 create mode 100644 .github/workflows/pull-request-lint.yml
 create mode 100644 .github/workflows/release.yml
 create mode 100644 .github/workflows/upgrade-master.yml
 create mode 100644 .gitignore
 create mode 100644 .mergify.yml
 create mode 100644 .npmignore
 create mode 100644 .projen/deps.json
 create mode 100644 .projen/files.json
 create mode 100644 .projen/tasks.json
 create mode 100644 .projenrc.js
 create mode 100644 LICENSE
 create mode 100644 README.md
 create mode 100644 package.json
 create mode 100644 src/index.ts
 create mode 100644 tsconfig.dev.json
 create mode 100644 yarn.lock

```

</details>

<details>
  <summary>Create L2 CDK constructor</summary>
  
 
```bash
./cdk.sh testCDK L2                                                                                                                    16.18.0 bazel 5.4.0
Generating L2 CDK resource
~/workspace/mongodbatlas-cloudformation-resources/cdk/l2-cdk-resources/testCDK ~/workspace/mongodbatlas-cloudformation-resources/cdk
👾 Project definition file was created at /Users/andrea.angiolillo/workspace/mongodbatlas-cloudformation-resources/cdk/l2-cdk-resources/testCDK/.projenrc.js
yarn install v1.22.19
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Saved lockfile.
✨  Done in 18.57s.
yarn install v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Saved lockfile.
✨  Done in 2.81s.

> @mongodbatlas-awscdk-l2/testCDK@0.0.0 eslint
> npx projen eslint

Initialized empty Git repository in /Users/andrea.angiolillo/workspace/mongodbatlas-cloudformation-resources/cdk/l2-cdk-resources/testCDK/.git/
[main (root-commit) af74c6c] chore: project created with projen
 19 files changed, 8072 insertions(+)
 create mode 100644 .eslintrc.json
 create mode 100644 .gitattributes
 create mode 100644 .github/pull_request_template.md
 create mode 100644 .github/workflows/build.yml
 create mode 100644 .github/workflows/pull-request-lint.yml
 create mode 100644 .github/workflows/release.yml
 create mode 100644 .github/workflows/upgrade-master.yml
 create mode 100644 .gitignore
 create mode 100644 .mergify.yml
 create mode 100644 .npmignore
 create mode 100644 .projen/deps.json
 create mode 100644 .projen/files.json
 create mode 100644 .projen/tasks.json
 create mode 100644 .projenrc.js
 create mode 100644 LICENSE
 create mode 100644 README.md
 create mode 100644 package.json
 create mode 100644 tsconfig.dev.json
 create mode 100644 yarn.lock
```

</details>


<details>
  <summary>Create L3 CDK constructor</summary>
  
 
```bash
./cdk.sh testCDK L3                                                                                                            26s  16.18.0 bazel 5.4.0
Generating L3 CDK resource
~/workspace/mongodbatlas-cloudformation-resources/cdk/l3-cdk-resources/testCDK ~/workspace/mongodbatlas-cloudformation-resources/cdk
👾 Project definition file was created at /Users/andrea.angiolillo/workspace/mongodbatlas-cloudformation-resources/cdk/l3-cdk-resources/testCDK/.projenrc.js
yarn install v1.22.19
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Saved lockfile.
✨  Done in 16.43s.
yarn install v1.22.19
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...

success Saved lockfile.
✨  Done in 3.07s.

> @mongodbatlas-awscdk-l3/testCDK@0.0.0 eslint
> npx projen eslint

Initialized empty Git repository in /Users/andrea.angiolillo/workspace/mongodbatlas-cloudformation-resources/cdk/l3-cdk-resources/testCDK/.git/
[main (root-commit) b0b0cb3] chore: project created with projen
 19 files changed, 8072 insertions(+)
 create mode 100644 .eslintrc.json
 create mode 100644 .gitattributes
 create mode 100644 .github/pull_request_template.md
 create mode 100644 .github/workflows/build.yml
 create mode 100644 .github/workflows/pull-request-lint.yml
 create mode 100644 .github/workflows/release.yml
 create mode 100644 .github/workflows/upgrade-master.yml
 create mode 100644 .gitignore
 create mode 100644 .mergify.yml
 create mode 100644 .npmignore
 create mode 100644 .projen/deps.json
 create mode 100644 .projen/files.json
 create mode 100644 .projen/tasks.json
 create mode 100644 .projenrc.js
 create mode 100644 LICENSE
 create mode 100644 README.md
 create mode 100644 package.json
 create mode 100644 tsconfig.dev.json
 create mode 100644 yarn.lock
```

</details>

<details>
  <summary>Wrong usage of the script</summary>

```bash

 ./cdk.sh testL2     
Error: please provide the resource name and the type of CDK constructor

Usage:
./cdk.sh   "<RESOURCE NAME>" "<L1|L2|L3>"

Example:
./cdk.sh cluster L1
```

</details>