### PR TITLE
Update env variables from MCLI to ATLAS

### DIFF
--- a/cfn-resources/third-party-integration/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/third-party-integration/test/cfn-test-create-inputs.sh
@@ -32,8 +32,8 @@ echo "Check if a project is created $projectId"
 cd "$(dirname "$0")" || exit
 for inputFile in inputs_*; do
 	outputFile=${inputFile//$WORDTOREMOVE/}
-	jq --arg pubkey "$MCLI_PUBLIC_API_KEY" \
-		--arg pvtkey "$MCLI_PRIVATE_API_KEY" \
+	jq --arg pubkey "$ATLAS_PUBLIC_KEY" \
+		--arg pvtkey "$ATLAS_PRIVATE_KEY" \
 		--arg ProjectId "$projectId" \
 		'.ProjectId?|=$ProjectId | .ApiKeys.PublicKey?|=$pubkey | .ApiKeys.PrivateKey?|=$pvtkey' \
 		"$inputFile" >"../inputs/$outputFile"


### PR DESCRIPTION
## Description

Change ATLAS keys env variables in test-create-input script for third party integration CFN resource.

Link to any related issue(s): 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

