### PR TITLE
Update script to use template folder

### DIFF
--- a/cfn-resources/cfn-submit-helper.sh
+++ b/cfn-resources/cfn-submit-helper.sh
@@ -62,7 +62,7 @@ for resource in ${resources}; do
 	[[ "${_DRY_RUN}" == "true" ]] && echo "[dry-run] would have run 'cfn submit' on:${resource}" && continue
 	cd "${resource}"
 	echo "resource: ${resource}"
-	echo "Submiting to CloudFormation with flags: ${CFN_SUBMIT_CFN_FLAGS}"
+	echo "Submitting to CloudFormation with flags: ${CFN_SUBMIT_CFN_FLAGS}"
 	cfn submit "${CFN_SUBMIT_CFN_FLAGS}" || true
 	cat rpdk.log
 	cd -

--- a/cfn-resources/project/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/project/test/cfn-test-create-inputs.sh
@@ -1,8 +1,23 @@
-#!/usr/bin/env bash
-# cfn-test-create-inputs.sh
+#!/bin/bash
+
+# Copyright 2023 MongoDB Inc
 #
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ./cfn-test-create-inputs.sh PROJECT_NAME
 # This tool generates json files in the inputs/ for `cfn test`.
-#
+
+set -euo pipefail
 
 function usage {
 	echo "usage:$0 <project_name>"
@@ -45,14 +60,14 @@ jq --arg pubkey "$ATLAS_PUBLIC_KEY" \
 	--arg key_id "$api_key_id" \
 	--arg team_id "$team_id" \
 	'.OrgId?|=$org | .ApiKeys.PublicKey?|=$pubkey | .ApiKeys.PrivateKey?|=$pvtkey | .Name?|=$name | .ProjectApiKeys[0].Key?|=$key_id | .ProjectTeams[0].TeamId?|=$team_id' \
-	"$(dirname "$0")/inputs_1_create.template.json" >"inputs/inputs_1_create.json"
+	"$(dirname "$0")/templates/inputs_1_create.template.json" >"inputs/inputs_1_create.json"
 
 jq --arg pubkey "$ATLAS_PUBLIC_KEY" \
 	--arg pvtkey "$ATLAS_PRIVATE_KEY" \
 	--arg org "$ATLAS_ORG_ID" \
 	--arg name "${name}- more B@d chars !@(!(@====*** ;;::" \
 	'.OrgId?|=$org | .ApiKeys.PublicKey?|=$pubkey | .ApiKeys.PrivateKey?|=$pvtkey | .Name?|=$name' \
-	"$(dirname "$0")/inputs_1_invalid.template.json" >"inputs/inputs_1_invalid.json"
+	"$(dirname "$0")/templates/inputs_1_invalid.template.json" >"inputs/inputs_1_invalid.json"
 
 jq --arg pubkey "$ATLAS_PUBLIC_KEY" \
 	--arg pvtkey "$ATLAS_PRIVATE_KEY" \
@@ -61,7 +76,7 @@ jq --arg pubkey "$ATLAS_PUBLIC_KEY" \
 	--arg key_id "$api_key_id" \
 	--arg team_id "$team_id" \
 	'.OrgId?|=$org | .ApiKeys.PublicKey?|=$pubkey | .ApiKeys.PrivateKey?|=$pvtkey | .Name?|=$name | .ProjectApiKeys[0].Key?|=$key_id | .ProjectTeams[0].TeamId?|=$team_id' \
-	"$(dirname "$0")/inputs_1_update.template.json" >"inputs/inputs_1_update.json"
+	"$(dirname "$0")/templates/inputs_1_update.template.json" >"inputs/inputs_1_update.json"
 
 ls -l inputs
 

--- a/cfn-resources/project/test/templates/inputs_1_create.template.json
+++ b/cfn-resources/project/test/templates/inputs_1_create.template.json
@@ -1,28 +1,32 @@
 {
-    "Name" : "Name",
-    "OrgId" : "$ATLAS_ORG_ID",
-    "ApiKeys" : {
-        "PublicKey" : "$ATLAS_PUBLIC_KEY",
-        "PrivateKey" : "$ATLAS_PRIVATE_KEY"
+    "Name":"Name",
+    "OrgId":"$ATLAS_ORG_ID",
+    "ApiKeys":{
+       "PublicKey":"$ATLAS_PUBLIC_KEY",
+       "PrivateKey":"$ATLAS_PRIVATE_KEY"
     },
-    "ProjectSettings": {
-        "IsCollectDatabaseSpecificsStatisticsEnabled": "false",
-        "IsDataExplorerEnabled": "false",
-        "IsPerformanceAdvisorEnabled": "false",
-        "IsRealtimePerformancePanelEnabled": "false",
-        "IsSchemaAdvisorEnabled": "true"
+    "ProjectSettings":{
+       "IsCollectDatabaseSpecificsStatisticsEnabled":"false",
+       "IsDataExplorerEnabled":"false",
+       "IsPerformanceAdvisorEnabled":"false",
+       "IsRealtimePerformancePanelEnabled":"false",
+       "IsSchemaAdvisorEnabled":"true"
     },
-		"ProjectApiKeys": [
-				{
-						"Key": "api_key_goes_here",
-						"RoleNames": ["GROUP_OWNER"]
-				}
-
-		],
-    "ProjectTeams": [
-        {
-            "TeamId": "Team_id_goes_here",
-            "RoleNames": ["GROUP_OWNER"]
-        }
+    "ProjectApiKeys":[
+       {
+          "Key":"api_key_goes_here",
+          "RoleNames":[
+             "GROUP_OWNER"
+          ]
+       }
+    ],
+    "ProjectTeams":[
+       {
+          "TeamId":"Team_id_goes_here",
+          "RoleNames":[
+             "GROUP_OWNER"
+          ]
+       }
     ]
-}
+ }
+ 

--- a/cfn-resources/project/test/templates/inputs_1_create.template.json
+++ b/cfn-resources/project/test/templates/inputs_1_create.template.json
@@ -12,13 +12,13 @@
         "IsRealtimePerformancePanelEnabled": "false",
         "IsSchemaAdvisorEnabled": "true"
     },
-    "ProjectApiKeys": [
-        {
-            "Key": "api_key_goes_here",
-            "RoleNames": ["GROUP_CLUSTER_MANAGER"]
-        }
+		"ProjectApiKeys": [
+				{
+						"Key": "api_key_goes_here",
+						"RoleNames": ["GROUP_OWNER"]
+				}
 
-    ],
+		],
     "ProjectTeams": [
         {
             "TeamId": "Team_id_goes_here",


### PR DESCRIPTION
## Description

While running `cfn test` for the project resource I run into some issues in generating the input file. This PR updates the script to use the new location of the template files/

Please include a summary of the fix/feature/change, including any relevant motivation and context.

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

