### PR TITLE
Updated teams resource to work with getAttr

### DIFF
--- a/cfn-resources/teams/docs/README.md
+++ b/cfn-resources/teams/docs/README.md
@@ -47,7 +47,7 @@ _Required_: No
 
 _Type_: String
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### RoleNames
 

--- a/cfn-resources/teams/mongodb-atlas-teams.json
+++ b/cfn-resources/teams/mongodb-atlas-teams.json
@@ -213,6 +213,10 @@
   ],
   "primaryIdentifier": [
     "/properties/TeamId",
+    "/properties/Profile",
+    "/properties/OrgId"
+  ],
+  "createOnlyProperties": [
     "/properties/Profile"
   ],
   "typeName": "MongoDB::Atlas::Teams"

--- a/examples/teams/teams.json
+++ b/examples/teams/teams.json
@@ -50,10 +50,13 @@
     }
   },
   "Outputs": {
-    "Teams": {
-      "Description": " teams",
+    "Users": {
+      "Description": "Users in the team.",
       "Value": {
-        "Ref": "Teams"
+        "Fn::GetAtt": [
+          "Teams",
+          "TeamId"
+        ]
       }
     }
   }

--- a/examples/teams/teams.json
+++ b/examples/teams/teams.json
@@ -50,8 +50,8 @@
     }
   },
   "Outputs": {
-    "Users": {
-      "Description": "Users in the team.",
+    "TeamId": {
+      "Description": "TeamId",
       "Value": {
         "Fn::GetAtt": [
           "Teams",


### PR DESCRIPTION
## Description

While trying to use GetAttr of the TeamId field I got the following errors: OrgId required in order to run the Get endpoint.
![Screenshot 2023-02-22 at 16 37 47](https://user-images.githubusercontent.com/5663078/220695538-ee7a714b-4f53-44f5-9743-0d929eb558cb.png)

This PR updates the resource definition to include the orgId
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments


