### PR TITLE
INTMDB-629: [CFN-PI] Update CFN release process to use "atlas cluster watch"

### DIFF
--- a/cfn-resources/cloud-backup-restore-jobs/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/cloud-backup-restore-jobs/test/cfn-test-create-inputs.sh
@@ -9,7 +9,7 @@ set -o pipefail
 set -x
 
 function usage {
-    echo "usage:$0 <project_name>"
+	echo "usage:$0 <project_name>"
 }
 
 if [ "$#" -ne 1 ]; then usage; fi
@@ -22,47 +22,31 @@ region="us-east-1"
 projectName="${1}"
 projectId=$(atlas projects list --output json | jq --arg NAME "${projectName}" -r '.results[] | select(.name==$NAME) | .id')
 if [ -z "$projectId" ]; then
-    projectId=$(atlas projects create "${projectName}" --output=json | jq -r '.id')
-    echo -e "Cant find project \"${projectName}\"\n"
+	projectId=$(atlas projects create "${projectName}" --output=json | jq -r '.id')
+	echo -e "Cant find project \"${projectName}\"\n"
 fi
 export MCLI_PROJECT_ID=$projectId
 ClusterName=$projectName
-clusterId=$(atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.id')
-
-status=""
-while [[ "${status}" != "IDLE" ]]; do
-        sleep 30
-        status=$(atlas clusters describe "${ClusterName}" --projectId "${projectId}"  --output=json | jq -r '.stateName')
-        if [ -z "$status" ]; then
-          status="timeout"
-        fi
-        echo "status: ${status}"
-done
-
-echo -e "Created Cluster \"${ClusterName}\" with id: ${clusterId}\n"
-
-if [ -z "$clusterId" ]; then
-    echo -e "Error Can't find Cluster \"${ClusterName}\""
-    exit 1
-fi
+atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json
+atlas clusters watch "${ClusterName}" --projectId "${projectId}"
+echo -e "Created Cluster \"${ClusterName}\""
 
 SnapshotId=$(atlas backup snapshots create "${ClusterName}" --desc "cfn unit test" --retention 3 --output=json | jq -r '.id')
 sleep 300
 
+jq --arg org "$ATLAS_ORG_ID" \
+	--arg ClusterName "$ClusterName" \
+	--arg group_id "$projectId" \
+	--arg SnapshotId "$SnapshotId" \
+	'.SnapshotId?|=$SnapshotId | .ProjectId?|=$group_id | .ClusterName?|=$ClusterName' \
+	"$(dirname "$0")/inputs_1_create.template.json" >"inputs/inputs_1_create.json"
 
 jq --arg org "$ATLAS_ORG_ID" \
-   --arg ClusterName "$ClusterName" \
-   --arg group_id "$projectId" \
-   --arg SnapshotId "$SnapshotId" \
-   '.SnapshotId?|=$SnapshotId | .ProjectId?|=$group_id | .ClusterName?|=$ClusterName' \
-   "$(dirname "$0")/inputs_1_create.template.json" > "inputs/inputs_1_create.json"
-
-jq --arg org "$ATLAS_ORG_ID" \
-   --arg region "${region}- more B@d chars !@(!(@====*** ;;::" \
-   --arg group_id "$projectId" \
-   --arg ClusterName "$ClusterName" \
-   --arg SnapshotId "$SnapshotId" \
-   '.SnapshotId?|=$SnapshotId |.ProjectId?|=$group_id | .ClusterName?|=$ClusterName' \
-   "$(dirname "$0")/inputs_1_invalid.template.json" > "inputs/inputs_1_invalid.json"
+	--arg region "${region}- more B@d chars !@(!(@====*** ;;::" \
+	--arg group_id "$projectId" \
+	--arg ClusterName "$ClusterName" \
+	--arg SnapshotId "$SnapshotId" \
+	'.SnapshotId?|=$SnapshotId |.ProjectId?|=$group_id | .ClusterName?|=$ClusterName' \
+	"$(dirname "$0")/inputs_1_invalid.template.json" >"inputs/inputs_1_invalid.json"
 
 ls -l inputs

--- a/cfn-resources/cloud-backup-schedule/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/cloud-backup-schedule/test/cfn-test-create-inputs.sh
@@ -34,14 +34,10 @@ export MCLI_PROJECT_ID=$projectId
 clusterId=$(atlas clusters list --projectId "${projectId}" --output json | jq --arg NAME "${clusterName}" -r '.results[]? | select(.name==$NAME) | .id')
 if [ -z "$clusterId" ]; then
 	echo "creating cluster.."
-	clusterId=$(atlas clusters create "${clusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.id')
+	atlas clusters create "${clusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json
+	atlas clusters watch "${clusterName}" --projectId "${projectId}"
+	echo -e "Created Cluster \"${clusterName}\""
 fi
-
-status=$(atlas clusters describe "${clusterName}" --projectId "${projectId}" --output=json | jq -r '.stateName')
-echo "status: ${status}"
-
-atlas clusters watch "${clusterName}" --projectId "${projectId}"
-echo -e "Created Cluster \"${clusterName}\" with id: ${clusterId}\n"
 
 policyId=$(atlas backups schedule describe "${clusterName}" --projectId "${projectId}" | jq -r '.policies[0].id')
 echo "policyId: ${policyId}"

--- a/cfn-resources/cloud-backup-schedule/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/cloud-backup-schedule/test/cfn-test-create-inputs.sh
@@ -9,10 +9,9 @@ set -o nounset
 set -o pipefail
 set -x
 
-
 function usage {
-    echo "usage:$0 <project_name>"
-    echo "Creates a new project and an Cluster for testing"
+	echo "usage:$0 <project_name>"
+	echo "Creates a new project and an Cluster for testing"
 }
 
 if [ "$#" -ne 2 ]; then usage; fi
@@ -27,52 +26,44 @@ echo "Creating required inputs"
 
 projectId=$(atlas projects list --output json | jq --arg NAME "${projectName}" -r '.results[] | select(.name==$NAME) | .id')
 if [ -z "$projectId" ]; then
-    projectId=$(atlas projects create "${projectName}" --output=json | jq -r '.id')
-    echo -e "Cant find project \"${projectName}\"\n"
+	projectId=$(atlas projects create "${projectName}" --output=json | jq -r '.id')
+	echo -e "Cant find project \"${projectName}\"\n"
 fi
 export MCLI_PROJECT_ID=$projectId
 
-clusterId=$(atlas clusters list --projectId "${projectId}"  --output json | jq --arg NAME "${clusterName}" -r '.results[]? | select(.name==$NAME) | .id')
+clusterId=$(atlas clusters list --projectId "${projectId}" --output json | jq --arg NAME "${clusterName}" -r '.results[]? | select(.name==$NAME) | .id')
 if [ -z "$clusterId" ]; then
-  echo "creating cluster.."
-  clusterId=$(atlas clusters create "${clusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.id')
+	echo "creating cluster.."
+	clusterId=$(atlas clusters create "${clusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.id')
 fi
 
 status=$(atlas clusters describe "${clusterName}" --projectId "${projectId}" --output=json | jq -r '.stateName')
 echo "status: ${status}"
 
-while [[ "${status}" != "IDLE" ]]; do
-        sleep 30
-        status=$(atlas clusters describe "${clusterName}" --projectId "${projectId}"  --output=json | jq -r '.stateName')
-        if [ -z "$status" ]; then
-          status="timeout"
-        fi
-        echo "status: ${status}"
-done
-
+atlas clusters watch "${clusterName}" --projectId "${projectId}"
 echo -e "Created Cluster \"${clusterName}\" with id: ${clusterId}\n"
 
 policyId=$(atlas backups schedule describe "${clusterName}" --projectId "${projectId}" | jq -r '.policies[0].id')
-echo  "policyId: ${policyId}"
+echo "policyId: ${policyId}"
 
 name="${1}"
 jq --arg group_id "$projectId" \
-   --arg cluster_name "$clusterName" \
-   --arg policy_id "$policyId" \
-   '.ClusterName?|=$cluster_name |.ProjectId?|=$group_id| .Policies[0].ID?|=$policy_id' \
-   "$(dirname "$0")/inputs_1_create.template.json" > "inputs/inputs_1_create.json"
+	--arg cluster_name "$clusterName" \
+	--arg policy_id "$policyId" \
+	'.ClusterName?|=$cluster_name |.ProjectId?|=$group_id| .Policies[0].ID?|=$policy_id' \
+	"$(dirname "$0")/inputs_1_create.template.json" >"inputs/inputs_1_create.json"
 
 jq --arg group_id "$projectId" \
-  --arg cluster_name "$clusterName" \
-  --arg policy_id "$policyId" \
-  '.ClusterName?|=$cluster_name |.ProjectId?|=$group_id| .Policies[0].ID?|=$policy_id' \
-  "$(dirname "$0")/inputs_1_update.template.json" > "inputs/inputs_1_update.json"
+	--arg cluster_name "$clusterName" \
+	--arg policy_id "$policyId" \
+	'.ClusterName?|=$cluster_name |.ProjectId?|=$group_id| .Policies[0].ID?|=$policy_id' \
+	"$(dirname "$0")/inputs_1_update.template.json" >"inputs/inputs_1_update.json"
 
 name="${name}- more B@d chars !@(!(@====*** ;;::"
 jq --arg group_id "$projectId" \
-   --arg cluster_name "$clusterName" \
-     '.ClusterName?|=$cluster_name |.ProjectId?|=$group_id' \
-   "$(dirname "$0")/inputs_1_invalid.template.json" > "inputs/inputs_1_invalid.json"
+	--arg cluster_name "$clusterName" \
+	'.ClusterName?|=$cluster_name |.ProjectId?|=$group_id' \
+	"$(dirname "$0")/inputs_1_invalid.template.json" >"inputs/inputs_1_invalid.json"
 
 echo "mongocli iam projects delete ${projectId} --force"
 ls -l inputs

--- a/cfn-resources/cloud-backup-snapshot/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/cloud-backup-snapshot/test/cfn-test-create-inputs.sh
@@ -31,14 +31,9 @@ if [ -z "$projectId" ]; then
 fi
 export MCLI_PROJECT_ID=$projectId
 
-clusterId=$(atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.id')
-sleep 900
-echo -e "Created Cluster \"${ClusterName}\" with id: ${clusterId}\n"
-
-if [ -z "$clusterId" ]; then
-	echo -e "Error Can't find Cluster \"${ClusterName}\""
-	exit 1
-fi
+atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json
+atlas clusters watch "${ClusterName}" --projectId "${projectId}"
+echo -e "Created Cluster \"${ClusterName}\""
 
 rm -rf inputs
 mkdir inputs

--- a/cfn-resources/datalakes/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/datalakes/test/cfn-test-create-inputs.sh
@@ -37,7 +37,7 @@ ClusterName="${projectName}"
 clusterId=$(atlas clusters list --output json | jq --arg NAME ${ClusterName} -r '.results[] | select(.name==$NAME) | .name')
 if [ -z "$clusterId" ]; then
 	clusterId=$(atlas cluster create ${ClusterName} --projectId "${projectId}" --provider AWS --region US_EAST_1 --members 3 --backup --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.name')
-	sleep 900
+	atlas clusters watch "${ClusterName}" --projectId "${projectId}"
 	echo -e "Created Cluster \"${ClusterName}\" with id: ${clusterId}\n"
 else
 	echo -e "FOUND Cluster \"${ClusterName}\" with id: ${clusterId}\n"

--- a/cfn-resources/global-cluster-config/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/global-cluster-config/test/cfn-test-create-inputs.sh
@@ -34,14 +34,9 @@ export MCLI_PROJECT_ID=$projectId
 
 ClusterName="${projectName}"
 
-clusterId=$(atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.id')
-sleep 1200
-echo -e "Created Cluster \"${ClusterName}\" with id: ${clusterId}\n"
-
-if [ -z "$clusterId" ]; then
-	echo -e "Error Can't find Cluster \"${ClusterName}\""
-	exit 1
-fi
+atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json
+atlas clusters watch "${ClusterName}" --projectId "${projectId}"
+echo -e "Created Cluster \"${ClusterName}\""
 
 atlas clusters loadSampleData "${ClusterName}" --projectId "${projectId}"
 

--- a/cfn-resources/online-archive/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/online-archive/test/cfn-test-create-inputs.sh
@@ -29,14 +29,9 @@ export MCLI_PROJECT_ID=$projectId
 ClusterName="${projectName}"
 
 # shellcheck disable=SC2086
-clusterId=$(atlas clusters create "${ClusterName}" --projectId ${projectId} --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.id')
-sleep 600
-echo -e "Created Cluster \"${ClusterName}\" with id: ${clusterId}\n"
-
-if [ -z "$clusterId" ]; then
-	echo -e "Error Can't find Cluster \"${ClusterName}\""
-	exit 1
-fi
+atlas clusters create "${ClusterName}" --projectId ${projectId} --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json
+atlas clusters watch "${ClusterName}" --projectId "${projectId}"
+echo -e "Created Cluster \"${ClusterName}\""
 
 atlas clusters loadSampleData "${ClusterName}" --projectId "${projectId}"
 

--- a/cfn-resources/search-index/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/search-index/test/cfn-test-create-inputs.sh
@@ -34,14 +34,9 @@ export MCLI_PROJECT_ID=$projectId
 
 ClusterName="${projectName}"
 
-clusterId=$(atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json | jq -r '.id')
-sleep 900
-echo -e "Created Cluster \"${ClusterName}\" with id: ${clusterId}\n"
-
-if [ -z "$clusterId" ]; then
-	echo -e "Error Can't find Cluster \"${ClusterName}\""
-	exit 1
-fi
+atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json
+atlas clusters watch "${ClusterName}" --projectId "${projectId}"
+echo -e "Created Cluster \"${ClusterName}\""
 
 atlas clusters loadSampleData "${ClusterName}" --projectId "${projectId}"
 


### PR DESCRIPTION

## Description

While releasing the search-index I noticed that the release process is using sleep 900 while waiting for cluster creation. This ticket is to update all these scripts to use atlas clusters watch

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

