### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: gomod
+    directory: "/cfn-resources"
+    schedule:
+      interval: daily
+    reviewers:
+      - "mongodb/apix-integrations"
+  - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
+    reviewers:
+      - "mongodb/apix-integrations"


### PR DESCRIPTION
## Description

Follow up of https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/351: I was wondering why dependabot did not upgrade the library -> the dependabot yaml file was pointing to the directory `/` which does not have the `go.mod` file. This PR updates the dependabot.yml to point to the correct directory.

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

