### PR TITLE
INTMDB 633 Network container delete handler hotfix

### DIFF
--- a/cfn-resources/network-container/cmd/resource/resource.go
+++ b/cfn-resources/network-container/cmd/resource/resource.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
@@ -207,6 +209,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	response, err := client.Containers.Delete(context.Background(), projectID, containerID)
 
 	if err != nil {
+		if response.StatusCode == 409 && strings.Contains(err.Error(), "try again") {
+			time.Sleep(time.Second * 3)
+			response, err = client.Containers.Delete(context.Background(), projectID, containerID)
+		}
 		return progressevents.GetFailedEventByResponse(fmt.Sprintf("Error getting resource : %s", err.Error()),
 			response.Response), nil
 	}

--- a/cfn-resources/network-container/cmd/resource/resource.go
+++ b/cfn-resources/network-container/cmd/resource/resource.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
@@ -209,12 +208,12 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	response, err := client.Containers.Delete(context.Background(), projectID, containerID)
 
 	if err != nil {
-		if response.StatusCode == 409 && strings.Contains(err.Error(), "try again") {
-			time.Sleep(time.Second * 3)
-			response, err = client.Containers.Delete(context.Background(), projectID, containerID)
+		time.Sleep(time.Second * 3)
+		response, err = client.Containers.Delete(context.Background(), projectID, containerID)
+		if err != nil {
+			return progressevents.GetFailedEventByResponse(fmt.Sprintf("Error getting resource : %s", err.Error()),
+				response.Response), nil
 		}
-		return progressevents.GetFailedEventByResponse(fmt.Sprintf("Error getting resource : %s", err.Error()),
-			response.Response), nil
 	}
 
 	return handler.ProgressEvent{

--- a/cfn-resources/network-container/cmd/resource/resource.go
+++ b/cfn-resources/network-container/cmd/resource/resource.go
@@ -17,6 +17,10 @@ package resource
 import (
 	"context"
 	"fmt"
+	"log"
+	"net/http"
+	"time"
+
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
@@ -25,9 +29,6 @@ import (
 	progressevents "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	"go.mongodb.org/atlas/mongodbatlas"
-	"log"
-	"net/http"
-	"time"
 )
 
 var CreateRequiredFields = []string{constants.ProjectID, constants.RegionName, constants.AtlasCIDRBlock}

--- a/cfn-resources/network-container/resource-role.yaml
+++ b/cfn-resources/network-container/resource-role.yaml
@@ -23,7 +23,28 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "secretsmanager:CreateSecret"
+                - "secretsmanager:CreateSecretInput"
+                - "secretsmanager:DescribeSecret"
                 - "secretsmanager:GetSecretValue"
+                - "secretsmanager:PutSecretValue"
+                - "secretsmanager:UpdateSecretVersionStage"
+                - "ec2:CreateVpcEndpoint"
+                - "ec2:DeleteVpcEndpoints"
+                - "cloudformation:CreateResource"
+                - "cloudformation:DeleteResource"
+                - "cloudformation:GetResource"
+                - "cloudformation:GetResourceRequestStatus"
+                - "cloudformation:ListResources"
+                - "cloudformation:UpdateResource"
+                - "iam:AttachRolePolicy"
+                - "iam:CreateRole"
+                - "iam:DeleteRole"
+                - "iam:GetRole"
+                - "iam:GetRolePolicy"
+                - "iam:ListAttachedRolePolicies"
+                - "iam:ListRolePolicies"
+                - "iam:PutRolePolicy"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/cfn-resources/network-container/resource-role.yaml
+++ b/cfn-resources/network-container/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/MongoDB-Atlas-NetworkContainer/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy
@@ -23,28 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                - "secretsmanager:CreateSecret"
-                - "secretsmanager:CreateSecretInput"
-                - "secretsmanager:DescribeSecret"
                 - "secretsmanager:GetSecretValue"
-                - "secretsmanager:PutSecretValue"
-                - "secretsmanager:UpdateSecretVersionStage"
-                - "ec2:CreateVpcEndpoint"
-                - "ec2:DeleteVpcEndpoints"
-                - "cloudformation:CreateResource"
-                - "cloudformation:DeleteResource"
-                - "cloudformation:GetResource"
-                - "cloudformation:GetResourceRequestStatus"
-                - "cloudformation:ListResources"
-                - "cloudformation:UpdateResource"
-                - "iam:AttachRolePolicy"
-                - "iam:CreateRole"
-                - "iam:DeleteRole"
-                - "iam:GetRole"
-                - "iam:GetRolePolicy"
-                - "iam:ListAttachedRolePolicies"
-                - "iam:ListRolePolicies"
-                - "iam:PutRolePolicy"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:


### PR DESCRIPTION
## Description

handling CANNOT_DELETE_RECENTLY_CREATED_CONTAINER error in network container DELETE handler.

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

