### PR TITLE
INTMDB-636: [CFN-PI] Add BASE_URL to CFN profile

### DIFF
--- a/cfn-resources/alert-configuration/cmd/resource/resource.go
+++ b/cfn-resources/alert-configuration/cmd/resource/resource.go
@@ -54,6 +54,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -99,6 +103,11 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *validationError, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -135,6 +144,11 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	validationError := validateRequest(RequiredFields, currentModel)
 	if validationError != nil {
 		return *validationError, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -197,6 +211,11 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *validationError, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -227,8 +246,12 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.ProgressEvent, error) {
 	setup() // logger setup
-
 	var err error
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil

--- a/cfn-resources/alert-configuration/cmd/resource/resource.go
+++ b/cfn-resources/alert-configuration/cmd/resource/resource.go
@@ -54,10 +54,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -103,11 +99,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *validationError, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -144,11 +135,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	validationError := validateRequest(RequiredFields, currentModel)
 	if validationError != nil {
 		return *validationError, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -211,11 +197,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *validationError, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -246,12 +227,8 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.ProgressEvent, error) {
 	setup() // logger setup
-	var err error
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
 
+	var err error
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil

--- a/cfn-resources/alert-configuration/cmd/resource/resource.go
+++ b/cfn-resources/alert-configuration/cmd/resource/resource.go
@@ -21,13 +21,13 @@ import (
 	"reflect"
 	"strings"
 
-	progressevents "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
-
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
+	progressevents "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	"github.com/openlyinc/pointy"
 	"github.com/spf13/cast"
@@ -55,7 +55,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -105,7 +105,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -148,7 +148,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -213,7 +213,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -249,7 +249,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	var err error
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/alert-configuration/template.yml
+++ b/cfn-resources/alert-configuration/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/alert-configuration/template.yml
+++ b/cfn-resources/alert-configuration/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/auditing/cmd/resource/resource.go
+++ b/cfn-resources/auditing/cmd/resource/resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -47,7 +48,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -111,7 +112,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -157,7 +158,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -235,7 +236,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/auditing/cmd/resource/resource.go
+++ b/cfn-resources/auditing/cmd/resource/resource.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -42,6 +43,11 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation != nil {
 		_, _ = log.Debugf("CRATE Validation Error")
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -103,6 +109,11 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -142,6 +153,11 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation != nil {
 		_, _ = log.Debugf("UPDATE Validation Error")
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -215,6 +231,11 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation != nil {
 		_, _ = log.Debugf("DELETE Validation Error")
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/auditing/cmd/resource/resource.go
+++ b/cfn-resources/auditing/cmd/resource/resource.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -43,11 +42,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation != nil {
 		_, _ = log.Debugf("CRATE Validation Error")
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -109,11 +103,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -153,11 +142,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation != nil {
 		_, _ = log.Debugf("UPDATE Validation Error")
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -231,11 +215,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation != nil {
 		_, _ = log.Debugf("DELETE Validation Error")
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/auditing/template.yml
+++ b/cfn-resources/auditing/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/auditing/template.yml
+++ b/cfn-resources/auditing/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/cloud-backup-restore-jobs/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-restore-jobs/cmd/resource/resource.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -42,10 +41,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation := validateModel(CreateRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
 	}
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
+
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -132,10 +128,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -209,10 +201,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -270,10 +258,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)

--- a/cfn-resources/cloud-backup-restore-jobs/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-restore-jobs/cmd/resource/resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -44,7 +45,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -134,7 +135,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -211,7 +212,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -272,7 +273,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {

--- a/cfn-resources/cloud-backup-restore-jobs/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-restore-jobs/cmd/resource/resource.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -41,7 +42,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation := validateModel(CreateRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
 	}
-
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -128,6 +132,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -201,6 +209,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -258,6 +270,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)

--- a/cfn-resources/cloud-backup-restore-jobs/template.yml
+++ b/cfn-resources/cloud-backup-restore-jobs/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/cloud-backup-restore-jobs/template.yml
+++ b/cfn-resources/cloud-backup-restore-jobs/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/cloud-backup-schedule/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-schedule/cmd/resource/resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -52,7 +53,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -73,7 +77,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -117,6 +124,10 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	_, _ = logger.Debugf("Update() currentModel:%+v", currentModel)
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -145,6 +156,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)

--- a/cfn-resources/cloud-backup-schedule/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-schedule/cmd/resource/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/cloud-backup-schedule/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-schedule/cmd/resource/resource.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -53,10 +52,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
+
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -77,10 +73,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
+
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -124,10 +117,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	_, _ = logger.Debugf("Update() currentModel:%+v", currentModel)
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -156,10 +145,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)

--- a/cfn-resources/cloud-backup-schedule/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-schedule/cmd/resource/resource.go
@@ -55,7 +55,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -79,7 +79,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -126,7 +126,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -158,7 +158,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {

--- a/cfn-resources/cloud-backup-schedule/template.yml
+++ b/cfn-resources/cloud-backup-schedule/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-backup-schedule/template.yml
+++ b/cfn-resources/cloud-backup-schedule/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/cloud-backup-snapshot-export-bucket/template.yml
+++ b/cfn-resources/cloud-backup-snapshot-export-bucket/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-backup-snapshot-export-bucket/template.yml
+++ b/cfn-resources/cloud-backup-snapshot-export-bucket/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/cloud-backup-snapshot-export-job/template.yml
+++ b/cfn-resources/cloud-backup-snapshot-export-job/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-backup-snapshot-export-job/template.yml
+++ b/cfn-resources/cloud-backup-snapshot-export-job/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/cloud-backup-snapshot/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-snapshot/cmd/resource/resource.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/cloud-backup-snapshot/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-snapshot/cmd/resource/resource.go
@@ -46,6 +46,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -115,6 +119,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 			cloudformation.HandlerErrorCodeInvalidRequest), nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -189,7 +197,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation := validateModel(DeleteRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
 	}
-
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -277,6 +288,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 			cloudformation.HandlerErrorCodeInvalidRequest), nil
 	}
 
+	// Create MongoDb Atlas Client using keys
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)

--- a/cfn-resources/cloud-backup-snapshot/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-snapshot/cmd/resource/resource.go
@@ -46,10 +46,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -119,10 +115,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 			cloudformation.HandlerErrorCodeInvalidRequest), nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -197,10 +189,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if modelValidation := validateModel(DeleteRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
 	}
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
+
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -288,10 +277,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 			cloudformation.HandlerErrorCodeInvalidRequest), nil
 	}
 
-	// Create MongoDb Atlas Client using keys
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)

--- a/cfn-resources/cloud-backup-snapshot/cmd/resource/resource.go
+++ b/cfn-resources/cloud-backup-snapshot/cmd/resource/resource.go
@@ -48,7 +48,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -121,7 +121,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -199,7 +199,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -290,7 +290,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create MongoDb Atlas Client using keys
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {

--- a/cfn-resources/cloud-backup-snapshot/template.yml
+++ b/cfn-resources/cloud-backup-snapshot/template.yml
@@ -26,4 +26,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/cloud-backup-snapshot/template.yml
+++ b/cfn-resources/cloud-backup-snapshot/template.yml
@@ -26,4 +26,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/cloud-provider-access/template.yml
+++ b/cfn-resources/cloud-provider-access/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/cloud-provider-access/template.yml
+++ b/cfn-resources/cloud-provider-access/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/cloud-provider-snapshot-restore-jobs/template.yml
+++ b/cfn-resources/cloud-provider-snapshot-restore-jobs/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/cloud-provider-snapshot-restore-jobs/template.yml
+++ b/cfn-resources/cloud-provider-snapshot-restore-jobs/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/cloud-provider-snapshots/template.yml
+++ b/cfn-resources/cloud-provider-snapshots/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/cloud-provider-snapshots/template.yml
+++ b/cfn-resources/cloud-provider-snapshots/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -80,7 +80,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -140,7 +140,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -183,7 +183,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -251,7 +251,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -303,7 +303,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -75,6 +76,11 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -132,6 +138,11 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	setup()
 	_, _ = log.Debugf("Read() currentModel:%+v", currentModel)
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -168,6 +179,11 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(UpdateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -233,6 +249,11 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -278,6 +299,11 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ListRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -76,11 +75,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -138,11 +132,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	setup()
 	_, _ = log.Debugf("Read() currentModel:%+v", currentModel)
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -179,11 +168,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(UpdateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -249,11 +233,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -299,11 +278,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ListRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/cluster/template.yml
+++ b/cfn-resources/cluster/template.yml
@@ -24,5 +24,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/cluster/template.yml
+++ b/cfn-resources/cluster/template.yml
@@ -24,5 +24,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/custom-db-role/cmd/resource/resource.go
+++ b/cfn-resources/custom-db-role/cmd/resource/resource.go
@@ -50,7 +50,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -89,7 +89,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -122,7 +122,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -171,7 +171,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -201,7 +201,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/custom-db-role/cmd/resource/resource.go
+++ b/cfn-resources/custom-db-role/cmd/resource/resource.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -45,6 +46,11 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validator.ValidateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -81,6 +87,11 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -107,6 +118,11 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validator.ValidateModel(UpdateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -153,6 +169,11 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -176,6 +197,11 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validator.ValidateModel(ListRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/custom-db-role/cmd/resource/resource.go
+++ b/cfn-resources/custom-db-role/cmd/resource/resource.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -46,11 +45,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validator.ValidateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -87,11 +81,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -118,11 +107,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validator.ValidateModel(UpdateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -169,11 +153,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -197,11 +176,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validator.ValidateModel(ListRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/custom-db-role/cmd/resource/resource.go
+++ b/cfn-resources/custom-db-role/cmd/resource/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	progress_events "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"

--- a/cfn-resources/custom-db-role/template.yml
+++ b/cfn-resources/custom-db-role/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/custom-db-role/template.yml
+++ b/cfn-resources/custom-db-role/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/custom-dns-configuration-cluster-aws/cmd/resource/resource.go
+++ b/cfn-resources/custom-dns-configuration-cluster-aws/cmd/resource/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/custom-dns-configuration-cluster-aws/cmd/resource/resource.go
+++ b/cfn-resources/custom-dns-configuration-cluster-aws/cmd/resource/resource.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -44,10 +43,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -71,10 +67,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -113,10 +106,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil

--- a/cfn-resources/custom-dns-configuration-cluster-aws/cmd/resource/resource.go
+++ b/cfn-resources/custom-dns-configuration-cluster-aws/cmd/resource/resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -43,7 +44,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -67,7 +71,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -106,7 +113,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		_, _ = logger.Warnf("Validation Error")
 		return *errEvent, nil
 	}
-
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil

--- a/cfn-resources/custom-dns-configuration-cluster-aws/cmd/resource/resource.go
+++ b/cfn-resources/custom-dns-configuration-cluster-aws/cmd/resource/resource.go
@@ -46,7 +46,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -73,7 +73,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -115,7 +115,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {

--- a/cfn-resources/custom-dns-configuration-cluster-aws/template.yml
+++ b/cfn-resources/custom-dns-configuration-cluster-aws/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/custom-dns-configuration-cluster-aws/template.yml
+++ b/cfn-resources/custom-dns-configuration-cluster-aws/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/database-user/cmd/resource/resource.go
+++ b/cfn-resources/database-user/cmd/resource/resource.go
@@ -55,7 +55,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -93,7 +93,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -167,7 +167,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -205,7 +205,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -240,7 +240,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {

--- a/cfn-resources/database-user/cmd/resource/resource.go
+++ b/cfn-resources/database-user/cmd/resource/resource.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/database-user/cmd/resource/resource.go
+++ b/cfn-resources/database-user/cmd/resource/resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
 	progress_events "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
+	"github.com/openlyinc/pointy"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -52,6 +53,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -86,6 +91,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -156,6 +165,10 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -190,6 +203,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -221,6 +238,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil

--- a/cfn-resources/database-user/cmd/resource/resource.go
+++ b/cfn-resources/database-user/cmd/resource/resource.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
 	progress_events "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
-	"github.com/openlyinc/pointy"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -53,10 +52,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -91,10 +86,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -165,10 +156,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -203,10 +190,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -238,10 +221,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil

--- a/cfn-resources/database-user/template.yml
+++ b/cfn-resources/database-user/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/database-user/template.yml
+++ b/cfn-resources/database-user/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/datalakes/template.yml
+++ b/cfn-resources/datalakes/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/datalakes/template.yml
+++ b/cfn-resources/datalakes/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/encryption-at-rest/cmd/resource/resource.go
+++ b/cfn-resources/encryption-at-rest/cmd/resource/resource.go
@@ -48,6 +48,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -87,6 +91,10 @@ func validateRequest(req *handler.Request, requiredFields []string, currentModel
 	// Validate required fields in the request
 	if modelValidation := validateModel(requiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil, errors.New("required field not found")
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(*req, currentModel.Profile)

--- a/cfn-resources/encryption-at-rest/cmd/resource/resource.go
+++ b/cfn-resources/encryption-at-rest/cmd/resource/resource.go
@@ -48,10 +48,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -91,10 +87,6 @@ func validateRequest(req *handler.Request, requiredFields []string, currentModel
 	// Validate required fields in the request
 	if modelValidation := validateModel(requiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil, errors.New("required field not found")
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(*req, currentModel.Profile)

--- a/cfn-resources/encryption-at-rest/cmd/resource/resource.go
+++ b/cfn-resources/encryption-at-rest/cmd/resource/resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/encryption-at-rest/cmd/resource/resource.go
+++ b/cfn-resources/encryption-at-rest/cmd/resource/resource.go
@@ -49,7 +49,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -94,7 +94,7 @@ func validateRequest(req *handler.Request, requiredFields []string, currentModel
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(*req, currentModel.Profile)

--- a/cfn-resources/encryption-at-rest/template.yml
+++ b/cfn-resources/encryption-at-rest/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/encryption-at-rest/template.yml
+++ b/cfn-resources/encryption-at-rest/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/federated-setting-org-configs/template.yml
+++ b/cfn-resources/federated-setting-org-configs/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/federated-setting-org-configs/template.yml
+++ b/cfn-resources/federated-setting-org-configs/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/federated-settings-identity-provider/template.yml
+++ b/cfn-resources/federated-settings-identity-provider/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/federated-settings-identity-provider/template.yml
+++ b/cfn-resources/federated-settings-identity-provider/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/federated-settings-org-role-mapping/template.yml
+++ b/cfn-resources/federated-settings-org-role-mapping/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/federated-settings-org-role-mapping/template.yml
+++ b/cfn-resources/federated-settings-org-role-mapping/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/global-cluster-config/template.yml
+++ b/cfn-resources/global-cluster-config/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/global-cluster-config/template.yml
+++ b/cfn-resources/global-cluster-config/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/ldap-configuration/template.yml
+++ b/cfn-resources/ldap-configuration/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/ldap-configuration/template.yml
+++ b/cfn-resources/ldap-configuration/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/ldap-verify/template.yml
+++ b/cfn-resources/ldap-verify/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/ldap-verify/template.yml
+++ b/cfn-resources/ldap-verify/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/legacy-cluster/template.yml
+++ b/cfn-resources/legacy-cluster/template.yml
@@ -24,5 +24,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/legacy-cluster/template.yml
+++ b/cfn-resources/legacy-cluster/template.yml
@@ -24,5 +24,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/maintenance-window/template.yml
+++ b/cfn-resources/maintenance-window/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/maintenance-window/template.yml
+++ b/cfn-resources/maintenance-window/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/network-container/cmd/resource/resource.go
+++ b/cfn-resources/network-container/cmd/resource/resource.go
@@ -50,7 +50,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -114,7 +114,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -151,7 +151,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -194,7 +194,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -241,7 +241,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {

--- a/cfn-resources/network-container/cmd/resource/resource.go
+++ b/cfn-resources/network-container/cmd/resource/resource.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/network-container/cmd/resource/resource.go
+++ b/cfn-resources/network-container/cmd/resource/resource.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -48,10 +47,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -112,10 +107,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -149,10 +140,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -192,10 +179,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -239,10 +222,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil

--- a/cfn-resources/network-container/cmd/resource/resource.go
+++ b/cfn-resources/network-container/cmd/resource/resource.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -47,6 +48,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -107,6 +112,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -140,6 +149,10 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -179,6 +192,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -222,6 +239,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil

--- a/cfn-resources/network-container/template.yml
+++ b/cfn-resources/network-container/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/network-container/template.yml
+++ b/cfn-resources/network-container/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/network-peering/template.yml
+++ b/cfn-resources/network-peering/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/network-peering/template.yml
+++ b/cfn-resources/network-peering/template.yml
@@ -24,4 +24,4 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/online-archive/template.yml
+++ b/cfn-resources/online-archive/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/online-archive/template.yml
+++ b/cfn-resources/online-archive/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/org-invitation/cmd/resource/resource.go
+++ b/cfn-resources/org-invitation/cmd/resource/resource.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -49,6 +50,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -91,6 +96,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -129,6 +138,10 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -165,6 +178,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -193,6 +210,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ListRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/org-invitation/cmd/resource/resource.go
+++ b/cfn-resources/org-invitation/cmd/resource/resource.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -50,10 +49,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -96,10 +91,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -138,10 +129,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -178,10 +165,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -210,10 +193,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ListRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/org-invitation/cmd/resource/resource.go
+++ b/cfn-resources/org-invitation/cmd/resource/resource.go
@@ -53,7 +53,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -97,7 +97,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -139,7 +139,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -179,7 +179,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -213,7 +213,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/org-invitation/cmd/resource/resource.go
+++ b/cfn-resources/org-invitation/cmd/resource/resource.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/org-invitation/template.yml
+++ b/cfn-resources/org-invitation/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/org-invitation/template.yml
+++ b/cfn-resources/org-invitation/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/private-endpoint-adl/template.yml
+++ b/cfn-resources/private-endpoint-adl/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/private-endpoint-adl/template.yml
+++ b/cfn-resources/private-endpoint-adl/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/private-endpoint-regional-mode/template.yml
+++ b/cfn-resources/private-endpoint-regional-mode/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/private-endpoint-regional-mode/template.yml
+++ b/cfn-resources/private-endpoint-regional-mode/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/private-endpoint/cmd/resource/steps/awsvpcendpoint/aws_vpc_endpoint.go
+++ b/cfn-resources/private-endpoint/cmd/resource/steps/awsvpcendpoint/aws_vpc_endpoint.go
@@ -54,7 +54,7 @@ func Create(req handler.Request, endpointServiceName string, region string, priv
 			subnetIdsIn[i] = &(pe.SubnetIDs[i])
 		}
 
-		connection := ec2.AcceptVpcPeeringConnectionInput{
+		connection := ec2.CreateVpcEndpointInput{
 			VpcId:           &pe.VpcID,
 			ServiceName:     &endpointServiceName,
 			VpcEndpointType: &vcpType,

--- a/cfn-resources/private-endpoint/cmd/resource/steps/awsvpcendpoint/aws_vpc_endpoint.go
+++ b/cfn-resources/private-endpoint/cmd/resource/steps/awsvpcendpoint/aws_vpc_endpoint.go
@@ -61,7 +61,6 @@ func Create(req handler.Request, endpointServiceName string, region string, priv
 			SubnetIds:       subnetIdsIn,
 		}
 
-		ec2.New()
 		vpcE, err := svc.CreateVpcEndpoint(&connection)
 		if err != nil {
 			fpe := progress_events.GetFailedEventByCode(fmt.Sprintf("Error creating vcp Endpoint: %s", err.Error()),

--- a/cfn-resources/private-endpoint/cmd/resource/steps/awsvpcendpoint/aws_vpc_endpoint.go
+++ b/cfn-resources/private-endpoint/cmd/resource/steps/awsvpcendpoint/aws_vpc_endpoint.go
@@ -54,13 +54,14 @@ func Create(req handler.Request, endpointServiceName string, region string, priv
 			subnetIdsIn[i] = &(pe.SubnetIDs[i])
 		}
 
-		connection := ec2.CreateVpcEndpointInput{
+		connection := ec2.AcceptVpcPeeringConnectionInput{
 			VpcId:           &pe.VpcID,
 			ServiceName:     &endpointServiceName,
 			VpcEndpointType: &vcpType,
 			SubnetIds:       subnetIdsIn,
 		}
 
+		ec2.New()
 		vpcE, err := svc.CreateVpcEndpoint(&connection)
 		if err != nil {
 			fpe := progress_events.GetFailedEventByCode(fmt.Sprintf("Error creating vcp Endpoint: %s", err.Error()),

--- a/cfn-resources/private-endpoint/template.yml
+++ b/cfn-resources/private-endpoint/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/private-endpoint/template.yml
+++ b/cfn-resources/private-endpoint/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/profile/profile.go
+++ b/cfn-resources/profile/profile.go
@@ -62,9 +62,9 @@ func (p *Profile) NewPrivateKey() string {
 		return k
 	}
 
-	return p.PublicKey
+	return p.PrivateKey
 }
 
 func (p *Profile) AreKeysAvailable() bool {
-	return p.NewPublicKey() != "" && p.PrivateKey != ""
+	return p.NewPublicKey() == "" || p.PrivateKey == ""
 }

--- a/cfn-resources/profile/profile.go
+++ b/cfn-resources/profile/profile.go
@@ -1,0 +1,70 @@
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+)
+
+const (
+	defaultProfile    = "default"
+	profileNamePrefix = "cfn/atlas/profile"
+)
+
+type Profile struct {
+	PublicKey     string `json:"PublicKey"`
+	PrivateKey    string `json:"PrivateKey"`
+	OpsManagerUrl string `json:"BaseUrl"`
+}
+
+func NewProfile(req *handler.Request, profileName *string) (*Profile, error) {
+	if profileName == nil || *profileName == "" {
+		profileName = aws.String(defaultProfile)
+	}
+
+	secretsManagerClient := secretsmanager.New(req.Session)
+	resp, err := secretsManagerClient.GetSecretValue(&secretsmanager.GetSecretValueInput{SecretId: aws.String(fmt.Sprintf("%s/%s", profileNamePrefix, *profileName))})
+	if err != nil {
+		return nil, err
+	}
+
+	profile := new(Profile)
+	err = json.Unmarshal([]byte(*resp.SecretString), &profile)
+	if err != nil {
+		return nil, err
+	}
+
+	return profile, nil
+}
+
+func (p *Profile) NewBaseURL() string {
+	if baseURL := os.Getenv("MONGODB_ATLAS_BASE_URL"); baseURL != "" {
+		return baseURL
+	}
+
+	return p.OpsManagerUrl
+}
+
+func (p *Profile) NewPublicKey() string {
+	if k := os.Getenv("MONGODB_ATLAS_PUBLIC_KEY"); k != "" {
+		return k
+	}
+
+	return p.PublicKey
+}
+
+func (p *Profile) NewPrivateKey() string {
+	if k := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY"); k != "" {
+		return k
+	}
+
+	return p.PublicKey
+}
+
+func (p *Profile) AreKeysAvailable() bool {
+	return p.NewPublicKey() != "" && p.PrivateKey != ""
+}

--- a/cfn-resources/profile/profile.go
+++ b/cfn-resources/profile/profile.go
@@ -37,7 +37,7 @@ type Profile struct {
 
 func NewProfile(req *handler.Request, profileName *string) (*Profile, error) {
 	if profileName == nil || *profileName == "" {
-		profileName = aws.String(defaultProfile)
+		profileName = aws.String(DefaultProfile)
 	}
 
 	secretsManagerClient := secretsmanager.New(req.Session)

--- a/cfn-resources/profile/profile.go
+++ b/cfn-resources/profile/profile.go
@@ -16,9 +16,9 @@ const (
 )
 
 type Profile struct {
-	PublicKey     string `json:"PublicKey"`
-	PrivateKey    string `json:"PrivateKey"`
-	OpsManagerUrl string `json:"BaseUrl"`
+	PublicKey  string `json:"PublicKey"`
+	PrivateKey string `json:"PrivateKey"`
+	BaseURL    string `json:"BaseUrl"`
 }
 
 func NewProfile(req *handler.Request, profileName *string) (*Profile, error) {
@@ -46,7 +46,7 @@ func (p *Profile) NewBaseURL() string {
 		return baseURL
 	}
 
-	return p.OpsManagerUrl
+	return p.BaseURL
 }
 
 func (p *Profile) NewPublicKey() string {

--- a/cfn-resources/profile/profile.go
+++ b/cfn-resources/profile/profile.go
@@ -1,3 +1,17 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package profile
 
 import (

--- a/cfn-resources/profile/profile.go
+++ b/cfn-resources/profile/profile.go
@@ -32,7 +32,7 @@ const (
 type Profile struct {
 	PublicKey  string `json:"PublicKey"`
 	PrivateKey string `json:"PrivateKey"`
-	BaseURL    string `json:"BaseUrl"`
+	BaseURL    string `json:"BaseUrl,omitempty"`
 }
 
 func NewProfile(req *handler.Request, profileName *string) (*Profile, error) {

--- a/cfn-resources/profile/profile.go
+++ b/cfn-resources/profile/profile.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	defaultProfile    = "default"
+	DefaultProfile    = "default"
 	profileNamePrefix = "cfn/atlas/profile"
 )
 

--- a/cfn-resources/project-invitation/cmd/resource/resource.go
+++ b/cfn-resources/project-invitation/cmd/resource/resource.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/project-invitation/cmd/resource/resource.go
+++ b/cfn-resources/project-invitation/cmd/resource/resource.go
@@ -54,7 +54,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -92,7 +92,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -134,7 +134,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -173,7 +173,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -208,7 +208,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/project-invitation/cmd/resource/resource.go
+++ b/cfn-resources/project-invitation/cmd/resource/resource.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -52,11 +51,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -88,11 +82,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ReadRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -132,11 +121,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -171,11 +155,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -204,11 +183,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ListRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/project-invitation/cmd/resource/resource.go
+++ b/cfn-resources/project-invitation/cmd/resource/resource.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -51,6 +52,11 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -82,6 +88,11 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ReadRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -121,6 +132,11 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -155,6 +171,11 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -183,6 +204,11 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ListRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/project-invitation/template.yml
+++ b/cfn-resources/project-invitation/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/project-invitation/template.yml
+++ b/cfn-resources/project-invitation/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/project-ip-access-list/cmd/resource/resource.go
+++ b/cfn-resources/project-ip-access-list/cmd/resource/resource.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
+
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
@@ -55,6 +57,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return progressevents.GetFailedEventByCode("AccessList must not be empty", cloudformation.HandlerErrorCodeInvalidRequest), nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	// Create atlas client
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -90,6 +96,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	if errEvent := validateModel(ReadRequiredFields, currentModel); errEvent != nil {
 		return *errEvent, nil
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -138,6 +148,10 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	// Create atlas client
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -170,6 +184,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	// Create atlas client
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -195,6 +213,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	if errEvent := validateModel(ListRequiredFields, currentModel); errEvent != nil {
 		return *errEvent, nil
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/project-ip-access-list/cmd/resource/resource.go
+++ b/cfn-resources/project-ip-access-list/cmd/resource/resource.go
@@ -58,7 +58,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -99,7 +99,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -149,7 +149,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -185,7 +185,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -216,7 +216,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/project-ip-access-list/cmd/resource/resource.go
+++ b/cfn-resources/project-ip-access-list/cmd/resource/resource.go
@@ -18,8 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
@@ -57,10 +55,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return progressevents.GetFailedEventByCode("AccessList must not be empty", cloudformation.HandlerErrorCodeInvalidRequest), nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	// Create atlas client
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -96,10 +90,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	if errEvent := validateModel(ReadRequiredFields, currentModel); errEvent != nil {
 		return *errEvent, nil
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -148,10 +138,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	// Create atlas client
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -184,10 +170,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	// Create atlas client
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -213,10 +195,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	if errEvent := validateModel(ListRequiredFields, currentModel); errEvent != nil {
 		return *errEvent, nil
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/project-ip-access-list/cmd/resource/resource.go
+++ b/cfn-resources/project-ip-access-list/cmd/resource/resource.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/project-ip-access-list/template.yml
+++ b/cfn-resources/project-ip-access-list/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/project-ip-access-list/template.yml
+++ b/cfn-resources/project-ip-access-list/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/project/cmd/resource/resource.go
+++ b/cfn-resources/project/cmd/resource/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/project/cmd/resource/resource.go
+++ b/cfn-resources/project/cmd/resource/resource.go
@@ -58,7 +58,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -143,7 +143,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	setup()
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -173,7 +173,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
@@ -325,7 +325,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (event h
 	setup()
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {

--- a/cfn-resources/project/cmd/resource/resource.go
+++ b/cfn-resources/project/cmd/resource/resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -56,6 +57,9 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -138,6 +142,9 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.ProgressEvent, error) {
 	setup()
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -165,6 +172,9 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 		return *errEvent, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -314,6 +324,9 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 func Delete(req handler.Request, prevModel *Model, currentModel *Model) (event handler.ProgressEvent, err error) {
 	setup()
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)

--- a/cfn-resources/project/cmd/resource/resource.go
+++ b/cfn-resources/project/cmd/resource/resource.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -57,9 +56,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -142,9 +138,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.ProgressEvent, error) {
 	setup()
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -172,9 +165,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 		return *errEvent, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
@@ -324,9 +314,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 func Delete(req handler.Request, prevModel *Model, currentModel *Model) (event handler.ProgressEvent, err error) {
 	setup()
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)

--- a/cfn-resources/project/resource-role.yaml
+++ b/cfn-resources/project/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/MongoDB-Atlas-Project/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/cfn-resources/project/resource-role.yaml
+++ b/cfn-resources/project/resource-role.yaml
@@ -15,13 +15,6 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-            Condition:
-              StringEquals:
-                aws:SourceAccount:
-                  Ref: AWS::AccountId
-              StringLike:
-                aws:SourceArn:
-                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/MongoDB-Atlas-Project/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/cfn-resources/project/template.yml
+++ b/cfn-resources/project/template.yml
@@ -24,5 +24,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/project/template.yml
+++ b/cfn-resources/project/template.yml
@@ -24,5 +24,5 @@ Resources:
         Variables:
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -50,10 +50,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -185,10 +181,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -233,10 +225,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	if errEvent := validateModel(UpdateRequiredFields, currentModel); errEvent != nil {
 		return *errEvent, nil
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -306,10 +294,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -354,10 +338,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	setup()
 	if errEvent := validateModel(UpdateRequiredFields, currentModel); errEvent != nil {
 		return *errEvent, nil
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
@@ -51,7 +52,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -186,7 +187,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -236,7 +237,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -307,7 +308,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -357,7 +358,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -50,6 +50,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -181,6 +185,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *errEvent, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -225,6 +233,10 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	if errEvent := validateModel(UpdateRequiredFields, currentModel); errEvent != nil {
 		return *errEvent, nil
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -294,6 +306,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *errEvent, nil
 	}
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -338,6 +354,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	setup()
 	if errEvent := validateModel(UpdateRequiredFields, currentModel); errEvent != nil {
 		return *errEvent, nil
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/search-index/template.yml
+++ b/cfn-resources/search-index/template.yml
@@ -29,4 +29,4 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:

--- a/cfn-resources/search-index/template.yml
+++ b/cfn-resources/search-index/template.yml
@@ -29,4 +29,4 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:

--- a/cfn-resources/serverless-instance/cmd/resource/resource.go
+++ b/cfn-resources/serverless-instance/cmd/resource/resource.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openlyinc/pointy"
-
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
@@ -56,10 +54,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/serverless-instance/cmd/resource/resource.go
+++ b/cfn-resources/serverless-instance/cmd/resource/resource.go
@@ -19,15 +19,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openlyinc/pointy"
-
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
 	progress_events "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
+	"github.com/openlyinc/pointy"
 	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
 )
 
@@ -59,7 +59,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/serverless-instance/cmd/resource/resource.go
+++ b/cfn-resources/serverless-instance/cmd/resource/resource.go
@@ -21,14 +21,14 @@ import (
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
+	userprofile "github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
-	progress_events "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
+	progressevent "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	"github.com/openlyinc/pointy"
-	mongodbatlas "go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas/mongodbatlas"
 )
 
 const (
@@ -59,7 +59,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(profile.DefaultProfile)
+		currentModel.Profile = pointy.String(userprofile.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -90,7 +90,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 				Message:          err.Error(),
 				HandlerErrorCode: cloudformation.HandlerErrorCodeAlreadyExists}, nil
 		}
-		return progress_events.GetFailedEventByResponse(err.Error(), res.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), res.Response), nil
 	}
 
 	return handler.ProgressEvent{
@@ -122,7 +122,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	cluster, res, err := client.ServerlessInstances.Get(context.Background(), *currentModel.ProjectID, *currentModel.Name)
 	if err != nil {
 		_, _ = log.Warnf("Read - error: %+v", err)
-		return progress_events.GetFailedEventByResponse(err.Error(), res.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), res.Response), nil
 	}
 	// Read Instance
 	model := readServerlessInstance(cluster, currentModel.Profile)
@@ -158,7 +158,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	_, res, err := client.ServerlessInstances.Get(context.Background(), *currentModel.ProjectID, *currentModel.Name)
 	if err != nil {
 		_, _ = log.Warnf("Read in Update - error: %+v", err)
-		return progress_events.GetFailedEventByResponse(err.Error(), res.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), res.Response), nil
 	}
 
 	serverlessInstanceRequest := &mongodbatlas.ServerlessUpdateRequestParams{
@@ -169,7 +169,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	serverless, res, err := client.ServerlessInstances.Update(context.Background(), *currentModel.ProjectID, *currentModel.Name, serverlessInstanceRequest)
 	if err != nil {
 		_, _ = log.Warnf("Update - error: %+v", err)
-		return progress_events.GetFailedEventByResponse(err.Error(), res.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), res.Response), nil
 	}
 	// Response
 	return handler.ProgressEvent{
@@ -207,7 +207,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	res, err := client.ServerlessInstances.Delete(context.Background(), *currentModel.ProjectID, *currentModel.Name)
 	if err != nil {
 		_, _ = log.Warnf("Delete - error: %+v", err)
-		return progress_events.GetFailedEventByResponse(err.Error(), res.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), res.Response), nil
 	}
 
 	// Response
@@ -244,7 +244,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	clustersResp, res, err := client.ServerlessInstances.List(context.Background(), *currentModel.ProjectID, listOptions)
 	if err != nil {
 		_, _ = log.Warnf("List - error: %+v", err)
-		return progress_events.GetFailedEventByResponse(err.Error(), res.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), res.Response), nil
 	}
 
 	instances := []interface{}{} // cfn test needs empty array instead nil, when items entries found
@@ -363,7 +363,7 @@ func serverlessCallback(client *mongodbatlas.Client, currentModel *Model, targtS
 			}, nil
 		}
 		_, _ = log.Warnf("Read - error: %+v", err)
-		return progress_events.GetFailedEventByResponse(err.Error(), resp.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), resp.Response), nil
 	}
 
 	currentModel.Id = &serverless.ID

--- a/cfn-resources/serverless-instance/cmd/resource/resource.go
+++ b/cfn-resources/serverless-instance/cmd/resource/resource.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openlyinc/pointy"
+
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
@@ -54,6 +56,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/serverless-instance/template.yml
+++ b/cfn-resources/serverless-instance/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/serverless-instance/template.yml
+++ b/cfn-resources/serverless-instance/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/teams/cmd/resource/resource.go
+++ b/cfn-resources/teams/cmd/resource/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/teams/cmd/resource/resource.go
+++ b/cfn-resources/teams/cmd/resource/resource.go
@@ -43,7 +43,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -96,7 +96,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -187,7 +187,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -294,7 +294,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	_, _ = logger.Debugf("List Teams  Request :%+v", currentModel)
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -352,7 +352,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	_, _ = logger.Debugf("Delete Team  Request() :%+v", currentModel)
 
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/teams/cmd/resource/resource.go
+++ b/cfn-resources/teams/cmd/resource/resource.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -40,10 +39,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	// Validate required fields in the request
 	if modelValidation := validateModel(CreateRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, errors.New("required field not found")
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -93,10 +88,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	// Validate required fields in the request
 	if modelValidation := validateModel(ReadRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -184,10 +175,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	// Validate required fields in the request
 	if modelValidation := validateModel(ReadRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, errors.New("required field not found")
-	}
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -293,10 +280,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	_, _ = logger.Debugf("List Teams  Request :%+v", currentModel)
 
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -350,10 +333,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	setup() // logger setup
 
 	_, _ = logger.Debugf("Delete Team  Request() :%+v", currentModel)
-
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {

--- a/cfn-resources/teams/cmd/resource/resource.go
+++ b/cfn-resources/teams/cmd/resource/resource.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -39,6 +40,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	// Validate required fields in the request
 	if modelValidation := validateModel(CreateRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, errors.New("required field not found")
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -88,6 +93,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	// Validate required fields in the request
 	if modelValidation := validateModel(ReadRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -175,6 +184,10 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	// Validate required fields in the request
 	if modelValidation := validateModel(ReadRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, errors.New("required field not found")
+	}
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
@@ -280,6 +293,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	_, _ = logger.Debugf("List Teams  Request :%+v", currentModel)
 
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", handlerError)
@@ -333,6 +350,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	setup() // logger setup
 
 	_, _ = logger.Debugf("Delete Team  Request() :%+v", currentModel)
+
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
 
 	client, handlerError := util.NewMongoDBClient(req, currentModel.Profile)
 	if handlerError != nil {

--- a/cfn-resources/teams/template.yml
+++ b/cfn-resources/teams/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/teams/template.yml
+++ b/cfn-resources/teams/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/third-party-integration/cmd/resource/resource.go
+++ b/cfn-resources/third-party-integration/cmd/resource/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	log "github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"

--- a/cfn-resources/third-party-integration/cmd/resource/resource.go
+++ b/cfn-resources/third-party-integration/cmd/resource/resource.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -62,11 +61,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	// Validation
 	if modelValidation := validateModel(RequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -116,11 +110,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -152,11 +141,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	// Validation
 	if modelValidation := validateModel(RequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -250,11 +234,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
-	}
-
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -289,11 +268,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	// Validation
 	if modelValidation := validateModel(ListRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	// Create atlas client
-	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/third-party-integration/cmd/resource/resource.go
+++ b/cfn-resources/third-party-integration/cmd/resource/resource.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
@@ -61,6 +62,11 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	// Validation
 	if modelValidation := validateModel(RequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -110,6 +116,11 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -141,6 +152,11 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	// Validation
 	if modelValidation := validateModel(RequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -234,6 +250,11 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
+	}
+
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
 		return *peErr, nil
@@ -268,6 +289,11 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	// Validation
 	if modelValidation := validateModel(ListRequiredFields, currentModel); modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	// Create atlas client
+	if currentModel.Profile == nil || *currentModel.Profile == "" {
+		currentModel.Profile = aws.String(util.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/third-party-integration/cmd/resource/resource.go
+++ b/cfn-resources/third-party-integration/cmd/resource/resource.go
@@ -66,7 +66,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -118,7 +118,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -156,7 +156,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -252,7 +252,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
@@ -293,7 +293,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	// Create atlas client
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
-		currentModel.Profile = aws.String(util.DefaultProfile)
+		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
 
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)

--- a/cfn-resources/third-party-integration/template.yml
+++ b/cfn-resources/third-party-integration/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/third-party-integration/template.yml
+++ b/cfn-resources/third-party-integration/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/trigger/template.yml
+++ b/cfn-resources/trigger/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/trigger/template.yml
+++ b/cfn-resources/trigger/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -93,10 +93,9 @@ func NewMongoDBClient(req handler.Request, profileName *string) (*mongodbatlas.C
 			OperationStatus:  handler.Failed,
 			Message:          err.Error(),
 			HandlerErrorCode: cloudformation.HandlerErrorCodeNotFound}
-
 	}
 
-	client, err := newHttpClient(p)
+	client, err := newHTTPClient(p)
 	if err != nil {
 		return nil, &handler.ProgressEvent{
 			OperationStatus:  handler.Failed,
@@ -115,13 +114,12 @@ func NewMongoDBClient(req handler.Request, profileName *string) (*mongodbatlas.C
 			OperationStatus:  handler.Failed,
 			Message:          err.Error(),
 			HandlerErrorCode: cloudformation.HandlerErrorCodeInvalidRequest}
-
 	}
 
 	return mongodbClient, nil
 }
 
-func newHttpClient(p *profile.Profile) (*http.Client, error) {
+func newHTTPClient(p *profile.Profile) (*http.Client, error) {
 	if p.AreKeysAvailable() {
 		return nil, errors.New("PublicKey and PrivateKey cannot be empty")
 	}

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -126,12 +126,8 @@ func newHttpClient(p *profile.Profile) (*http.Client, error) {
 		return nil, errors.New("PublicKey and PrivateKey cannot be empty")
 	}
 
-	t := &digest.Transport{
-		Username: p.NewPublicKey(),
-		Password: p.NewPrivateKey(),
-	}
-
-	return &http.Client{Transport: t}, nil
+	t := digest.NewTransport(p.NewPublicKey(), p.NewPrivateKey())
+	return t.Client()
 }
 
 // defaultLogLevel can be set during compile time with an ld flag to enable

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -16,31 +16,30 @@ package util
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"runtime"
 	"strings"
 
-	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
-	"github.com/aws/aws-sdk-go/service/cloudformation"
-	progress_events "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
-
 	"github.com/Sectorbob/mlab-ns2/gae/ns/digest"
+	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/logging"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/version"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 
 const (
-	cfn            = "mongodbatlas-cloudformation-resources"
-	DefaultProfile = "default"
-	envLogLevel    = "LOG_LEVEL"
-	debug          = "debug"
-	profileName    = "cfn/atlas/profile/%s"
+	cfn         = "mongodbatlas-cloudformation-resources"
+	envLogLevel = "LOG_LEVEL"
+	debug       = "debug"
 )
 
 var (
@@ -80,50 +79,59 @@ func CreateMongoDBClient(publicKey, privateKey string) (*mongodbatlas.Client, er
 	}
 
 	opts := []mongodbatlas.ClientOpt{mongodbatlas.SetUserAgent(userAgent)}
-	if baseURL := os.Getenv("MONGODB_ATLAS_OPS_MANAGER_URL"); baseURL != "" {
+	if baseURL := os.Getenv("MONGODB_ATLAS_BASE_URL"); baseURL != "" {
 		opts = append(opts, mongodbatlas.SetBaseURL(baseURL))
 	}
 
 	return mongodbatlas.New(client, opts...)
 }
 
-func NewMongoDBClient(req handler.Request, profile *string) (*mongodbatlas.Client, *handler.ProgressEvent) {
-	profileInput := DefaultProfile
-	if profile != nil {
-		profileInput = *profile
-	}
-
-	keys, handlerError := getAPIKeys(req, profileInput)
-	if handlerError != nil {
-		return nil, handlerError
-	}
-
-	// Create atlas client
-	client, err := CreateMongoDBClient(keys.PublicKey, keys.PrivateKey)
+func NewMongoDBClient(req handler.Request, profileName *string) (*mongodbatlas.Client, *handler.ProgressEvent) {
+	p, err := profile.NewProfile(&req, profileName)
 	if err != nil {
-		_, _ = logger.Warnf("Create - error: %+v", err)
-		peErr := progress_events.GetFailedEventByCode(fmt.Sprintf("Error creating mongoDB client : %s", err.Error()),
-			cloudformation.HandlerErrorCodeInvalidRequest)
-		return nil, &peErr
+		return nil, &handler.ProgressEvent{
+			OperationStatus:  handler.Failed,
+			Message:          err.Error(),
+			HandlerErrorCode: cloudformation.HandlerErrorCodeNotFound}
+
 	}
 
-	return client, nil
+	client, err := newHttpClient(p)
+	if err != nil {
+		return nil, &handler.ProgressEvent{
+			OperationStatus:  handler.Failed,
+			Message:          fmt.Sprintf("Error creating mongoDB client : %s", err.Error()),
+			HandlerErrorCode: cloudformation.HandlerErrorCodeInvalidRequest}
+	}
+
+	opts := []mongodbatlas.ClientOpt{mongodbatlas.SetUserAgent(userAgent)}
+	if baseURL := p.NewBaseURL(); baseURL != "" {
+		opts = append(opts, mongodbatlas.SetBaseURL(baseURL))
+	}
+
+	mongodbClient, err := mongodbatlas.New(client, opts...)
+	if err != nil {
+		return nil, &handler.ProgressEvent{
+			OperationStatus:  handler.Failed,
+			Message:          err.Error(),
+			HandlerErrorCode: cloudformation.HandlerErrorCodeInvalidRequest}
+
+	}
+
+	return mongodbClient, nil
 }
 
-func getAPIKeys(req handler.Request, profile string) (*DeploymentSecret, *handler.ProgressEvent) {
-	key, err := GetAPIKeyFromDeploymentSecret(&req, fmt.Sprintf(profileName, profile))
-	if err != nil {
-		_, _ = logger.Warnf("Read - error: %+v", err)
-		pe := handler.ProgressEvent{
-			OperationStatus: handler.Failed,
-			Message: fmt.Sprintf("Error getting API-key, API-key needs to be provided using an AWS secret,"+
-				"  Ensure a secret named 'cfn/atlas/profile/%s' is created with the 'PublicKey' and 'PrivateKey' properties, error: %s",
-				profile, err.Error()),
-			HandlerErrorCode: cloudformation.HandlerErrorCodeNotFound}
-		return nil, &pe
+func newHttpClient(p *profile.Profile) (*http.Client, error) {
+	if p.AreKeysAvailable() {
+		return nil, errors.New("PublicKey and PrivateKey cannot be empty")
 	}
 
-	return &key, nil
+	t := &digest.Transport{
+		Username: p.NewPublicKey(),
+		Password: p.NewPrivateKey(),
+	}
+
+	return &http.Client{Transport: t}, nil
 }
 
 // defaultLogLevel can be set during compile time with an ld flag to enable

--- a/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
+++ b/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
@@ -20,15 +20,15 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/spf13/cast"
-
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	"github.com/openlyinc/pointy"
+	"github.com/spf13/cast"
 	"go.mongodb.org/atlas/mongodbatlas"
 )
 

--- a/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
+++ b/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
@@ -45,10 +45,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
-	}
-
 	// Create atlas client
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -117,10 +113,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ReadRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -202,10 +194,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
-	}
-
-	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
+++ b/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
@@ -46,7 +46,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -120,7 +120,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -205,7 +205,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if currentModel.Profile == nil {
-		currentModel.Profile = pointy.String(util.DefaultProfile)
+		currentModel.Profile = pointy.String(profile.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
+++ b/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
@@ -45,6 +45,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
+	}
+
 	// Create atlas client
 	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
 	if peErr != nil {
@@ -113,6 +117,10 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	modelValidation := validateModel(ReadRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
 	}
 
 	// Create atlas client
@@ -194,6 +202,10 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	modelValidation := validateModel(CreateRequiredFields, currentModel)
 	if modelValidation != nil {
 		return *modelValidation, nil
+	}
+
+	if currentModel.Profile == nil {
+		currentModel.Profile = pointy.String(util.DefaultProfile)
 	}
 
 	// Create atlas client

--- a/cfn-resources/x509-authentication-database-user/template.yml
+++ b/cfn-resources/x509-authentication-database-user/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_OPS_MANAGER_URL:
+          MONGODB_ATLAS_BASE_URL:
 

--- a/cfn-resources/x509-authentication-database-user/template.yml
+++ b/cfn-resources/x509-authentication-database-user/template.yml
@@ -25,5 +25,5 @@ Resources:
         Variables: 
           MODE: Test
           LOG_LEVEL: debug
-          MONGODB_ATLAS_BASE_URL:
+          MONGODB_ATLAS_OPS_MANAGER_URL:
 


### PR DESCRIPTION
## Description

This PR introduces the `baseUrl` to the CFN profile. This property will allow us to test CFN resources and Quickstart templates again cloud-dev instead of atlas production.

Ticket: [INTMDB-636](https://jira.mongodb.org/browse/INTMDB-636)

**Template:**
```json
{"PublicKey":"lzwmyjgh","PrivateKey":"privateKey","BaseUrl":"https://cloud-dev.mongodb.com/"}
```

**Additional Info:**
- If the property is not provided, CFN defaults to atlas production


**Testing:**

- I tested my changes by running cfn test 
- I tested my changes by releasing the project resource to the private registry and defined a cfn stack


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

**Next Steps:**

- Remove the deprecated`CreateMongoDBClient` once all the cfn resources have migrated to the new one
- Move the mongoClient  away from the util folder

