### PR TITLE
Fix params for create-test-inputs script for trigger

### DIFF
--- a/cfn-resources/trigger/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/trigger/test/cfn-test-create-inputs.sh
@@ -35,14 +35,15 @@ if [[ "$*" == help ]]; then usage; fi
 rm -rf inputs
 mkdir inputs
 
-project_Id="${1:-$PROJECT_ID}"
-db_name="${2:-$DB_NAME}"
-coll_name="${3:-$COLLECTION_NAME}"
+# params start from #2 because cfn-testing-helper.sh calls these scripts with PROJECT_NAME as a param
+project_Id="${2:-$PROJECT_ID}"
+db_name="${3:-$DB_NAME}"
+coll_name="${4:-$COLLECTION_NAME}"
 trigger_name="cfn-test-trigger-${RANDOM}"
-func_name="${4:-$FUNC_NAME}"
-func_id="${5:-$FUNC_ID}"
-service_id="${6:-$SERVICE_ID}"
-app_id="${7:-$APP_ID}"
+func_name="${5:-$FUNC_NAME}"
+func_id="${6:-$FUNC_ID}"
+service_id="${7:-$SERVICE_ID}"
+app_id="${8:-$APP_ID}"
 
 WORDTOREMOVE="template."
 cd "$(dirname "$0")" || exit


### PR DESCRIPTION
## Description

Updating input params passed to create-test-inputs script for Trigger CFN resource based on how script is invoked when publishing.

Link to any related issue(s): 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

