### PR TITLE
Fixed CDK Cloud Backup Schedule read only properties

### DIFF
--- a/cdk/cdk-resources/cloud-backup-schedule/API.md
+++ b/cdk/cdk-resources/cloud-backup-schedule/API.md
@@ -404,9 +404,7 @@ Check whether the given construct is a CfnResource.
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.cfnOptions">cfnOptions</a></code> | <code>aws-cdk-lib.ICfnResourceOptions</code> | Options for this resource, such as condition, update policy etc. |
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.cfnResourceType">cfnResourceType</a></code> | <code>string</code> | AWS resource type. |
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.attrClusterId">attrClusterId</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::CloudBackupSchedule.ClusterId`. |
-| <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.attrClusterName">attrClusterName</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::CloudBackupSchedule.ClusterName`. |
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.attrNextSnapshot">attrNextSnapshot</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::CloudBackupSchedule.NextSnapshot`. |
-| <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.attrProjectId">attrProjectId</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::CloudBackupSchedule.ProjectId`. |
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.props">props</a></code> | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps">CfnCloudBackupScheduleProps</a></code> | Resource props. |
 
 ---
@@ -515,18 +513,6 @@ Attribute `MongoDB::Atlas::CloudBackupSchedule.ClusterId`.
 
 ---
 
-##### `attrClusterName`<sup>Required</sup> <a name="attrClusterName" id="@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.attrClusterName"></a>
-
-```typescript
-public readonly attrClusterName: string;
-```
-
-- *Type:* string
-
-Attribute `MongoDB::Atlas::CloudBackupSchedule.ClusterName`.
-
----
-
 ##### `attrNextSnapshot`<sup>Required</sup> <a name="attrNextSnapshot" id="@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.attrNextSnapshot"></a>
 
 ```typescript
@@ -536,18 +522,6 @@ public readonly attrNextSnapshot: string;
 - *Type:* string
 
 Attribute `MongoDB::Atlas::CloudBackupSchedule.NextSnapshot`.
-
----
-
-##### `attrProjectId`<sup>Required</sup> <a name="attrProjectId" id="@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupSchedule.property.attrProjectId"></a>
-
-```typescript
-public readonly attrProjectId: string;
-```
-
-- *Type:* string
-
-Attribute `MongoDB::Atlas::CloudBackupSchedule.ProjectId`.
 
 ---
 
@@ -864,7 +838,9 @@ const cfnCloudBackupScheduleProps: CfnCloudBackupScheduleProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.clusterName">clusterName</a></code> | <code>string</code> | The name of the Atlas cluster that contains the snapshots you want to retrieve. |
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.profile">profile</a></code> | <code>string</code> | Profile used to provide credentials information, (a secret with the cfn/atlas/profile/{Profile}, is required), if not provided default is used. |
+| <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.projectId">projectId</a></code> | <code>string</code> | Unique 24-hexadecimal digit string that identifies your project. |
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.autoExportEnabled">autoExportEnabled</a></code> | <code>boolean</code> | Flag that indicates whether automatic export of cloud backup snapshots to the AWS bucket is enabled. |
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.copySettings">copySettings</a></code> | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.ApiAtlasDiskBackupCopySettingView">ApiAtlasDiskBackupCopySettingView</a>[]</code> | List that contains a document for each copy setting item in the desired backup policy. |
 | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.deleteCopiedBackups">deleteCopiedBackups</a></code> | <code><a href="#@mongodbatlas-awscdk/cloud-backup-schedule.ApiDeleteCopiedBackupsView">ApiDeleteCopiedBackupsView</a>[]</code> | List that contains a document for each deleted copy setting whose backup copies you want to delete. |
@@ -880,6 +856,18 @@ const cfnCloudBackupScheduleProps: CfnCloudBackupScheduleProps = { ... }
 
 ---
 
+##### `clusterName`<sup>Required</sup> <a name="clusterName" id="@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.clusterName"></a>
+
+```typescript
+public readonly clusterName: string;
+```
+
+- *Type:* string
+
+The name of the Atlas cluster that contains the snapshots you want to retrieve.
+
+---
+
 ##### `profile`<sup>Required</sup> <a name="profile" id="@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.profile"></a>
 
 ```typescript
@@ -889,6 +877,18 @@ public readonly profile: string;
 - *Type:* string
 
 Profile used to provide credentials information, (a secret with the cfn/atlas/profile/{Profile}, is required), if not provided default is used.
+
+---
+
+##### `projectId`<sup>Required</sup> <a name="projectId" id="@mongodbatlas-awscdk/cloud-backup-schedule.CfnCloudBackupScheduleProps.property.projectId"></a>
+
+```typescript
+public readonly projectId: string;
+```
+
+- *Type:* string
+
+Unique 24-hexadecimal digit string that identifies your project.
 
 ---
 

--- a/cdk/cdk-resources/cloud-backup-schedule/src/index.ts
+++ b/cdk/cdk-resources/cloud-backup-schedule/src/index.ts
@@ -16,6 +16,20 @@ export interface CfnCloudBackupScheduleProps {
   readonly id?: string;
 
   /**
+   * Unique 24-hexadecimal digit string that identifies your project.
+   *
+   * @schema CfnCloudBackupScheduleProps#ProjectId
+   */
+  readonly projectId: string;
+
+  /**
+   * The name of the Atlas cluster that contains the snapshots you want to retrieve.
+   *
+   * @schema CfnCloudBackupScheduleProps#ClusterName
+   */
+  readonly clusterName: string;
+
+  /**
    * Flag that indicates whether automatic export of cloud backup snapshots to the AWS bucket is enabled.
    *
    * @schema CfnCloudBackupScheduleProps#AutoExportEnabled
@@ -109,6 +123,8 @@ export function toJson_CfnCloudBackupScheduleProps(obj: CfnCloudBackupSchedulePr
   if (obj === undefined) { return undefined; }
   const result = {
     'Id': obj.id,
+    'ProjectId': obj.projectId,
+    'ClusterName': obj.clusterName,
     'AutoExportEnabled': obj.autoExportEnabled,
     'UseOrgAndGroupNamesInExportPrefix': obj.useOrgAndGroupNamesInExportPrefix,
     'Export': toJson_Export(obj.export),
@@ -415,14 +431,6 @@ export class CfnCloudBackupSchedule extends cdk.CfnResource {
    * Attribute `MongoDB::Atlas::CloudBackupSchedule.NextSnapshot`
    */
   public readonly attrNextSnapshot: string;
-  /**
-   * Attribute `MongoDB::Atlas::CloudBackupSchedule.ProjectId`
-   */
-  public readonly attrProjectId: string;
-  /**
-   * Attribute `MongoDB::Atlas::CloudBackupSchedule.ClusterName`
-   */
-  public readonly attrClusterName: string;
 
   /**
    * Create a new `MongoDB::Atlas::CloudBackupSchedule`.
@@ -438,7 +446,5 @@ export class CfnCloudBackupSchedule extends cdk.CfnResource {
 
     this.attrClusterId = cdk.Token.asString(this.getAtt('ClusterId'));
     this.attrNextSnapshot = cdk.Token.asString(this.getAtt('NextSnapshot'));
-    this.attrProjectId = cdk.Token.asString(this.getAtt('ProjectId'));
-    this.attrClusterName = cdk.Token.asString(this.getAtt('ClusterName'));
   }
 }

--- a/cdk/cdk-resources/cloud-backup-schedule/test/index.test.ts
+++ b/cdk/cdk-resources/cloud-backup-schedule/test/index.test.ts
@@ -1,0 +1,42 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { App, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { CfnCloudBackupSchedule } from '../src/index';
+
+
+const RESOURCE_NAME = 'MongoDB::Atlas::CloudBackupSchedule';
+const PROJECT_ID= 'testProjectId';
+const CLUSTER_NAME = 'test_host_name';
+const PROFILE = 'default';
+
+test('CloudBackupSchedule construct should contain default properties', () => {
+  const mockApp = new App();
+  const stack = new Stack(mockApp);
+
+  new CfnCloudBackupSchedule(stack, 'testing-stack', {
+    projectId: PROJECT_ID,
+    clusterName: CLUSTER_NAME,
+    profile: PROFILE,
+  });
+
+  const template = Template.fromStack(stack);
+
+  template.hasResourceProperties(RESOURCE_NAME, {
+    ProjectId: PROJECT_ID,
+    ClusterName: CLUSTER_NAME,
+    Profile: PROFILE,
+  });
+});


### PR DESCRIPTION
## Description

In the Cloud Backup Schedule the ProjectId and ClusterName were set as read only and were not provided as an input Parameter

Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

