### PR TITLE
Fixed maintenance window profile bug fix

### DIFF
--- a/cdk/cdk-resources/maintenance-window/API.md
+++ b/cdk/cdk-resources/maintenance-window/API.md
@@ -403,8 +403,6 @@ Check whether the given construct is a CfnResource.
 | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.ref">ref</a></code> | <code>string</code> | Return a string that will be resolved to a CloudFormation `{ Ref }` for this element. |
 | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.cfnOptions">cfnOptions</a></code> | <code>aws-cdk-lib.ICfnResourceOptions</code> | Options for this resource, such as condition, update policy etc. |
 | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.cfnResourceType">cfnResourceType</a></code> | <code>string</code> | AWS resource type. |
-| <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.attrAutoDeferOnceEnabled">attrAutoDeferOnceEnabled</a></code> | <code>aws-cdk-lib.IResolvable</code> | Attribute `MongoDB::Atlas::MaintenanceWindow.AutoDeferOnceEnabled`. |
-| <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.attrProjectId">attrProjectId</a></code> | <code>string</code> | Attribute `MongoDB::Atlas::MaintenanceWindow.ProjectId`. |
 | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.props">props</a></code> | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps">CfnMaintenanceWindowProps</a></code> | Resource props. |
 
 ---
@@ -501,30 +499,6 @@ AWS resource type.
 
 ---
 
-##### `attrAutoDeferOnceEnabled`<sup>Required</sup> <a name="attrAutoDeferOnceEnabled" id="@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.attrAutoDeferOnceEnabled"></a>
-
-```typescript
-public readonly attrAutoDeferOnceEnabled: IResolvable;
-```
-
-- *Type:* aws-cdk-lib.IResolvable
-
-Attribute `MongoDB::Atlas::MaintenanceWindow.AutoDeferOnceEnabled`.
-
----
-
-##### `attrProjectId`<sup>Required</sup> <a name="attrProjectId" id="@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.attrProjectId"></a>
-
-```typescript
-public readonly attrProjectId: string;
-```
-
-- *Type:* string
-
-Attribute `MongoDB::Atlas::MaintenanceWindow.ProjectId`.
-
----
-
 ##### `props`<sup>Required</sup> <a name="props" id="@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindow.property.props"></a>
 
 ```typescript
@@ -576,8 +550,10 @@ const cfnMaintenanceWindowProps: CfnMaintenanceWindowProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps.property.hourOfDay">hourOfDay</a></code> | <code>number</code> | Zero-based integer that represents the hour of the of the day that the maintenance window starts according to a 24-hour clock. |
+| <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps.property.autoDeferOnceEnabled">autoDeferOnceEnabled</a></code> | <code>boolean</code> | Flag that indicates whether MongoDB Cloud should defer all maintenance windows for one week after you enable them. |
 | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps.property.dayOfWeek">dayOfWeek</a></code> | <code>number</code> | One-based integer that represents the day of the week that the maintenance window starts. |
 | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps.property.profile">profile</a></code> | <code>string</code> | The profile is defined in AWS Secret manager. |
+| <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps.property.projectId">projectId</a></code> | <code>string</code> | Unique 24-hexadecimal digit string that identifies your project. |
 | <code><a href="#@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps.property.startAsap">startAsap</a></code> | <code>boolean</code> | Flag that indicates whether MongoDB Cloud starts the maintenance window immediately upon receiving this request. |
 
 ---
@@ -593,6 +569,18 @@ public readonly hourOfDay: number;
 Zero-based integer that represents the hour of the of the day that the maintenance window starts according to a 24-hour clock.
 
 Use `0` for midnight and `12` for noon.
+
+---
+
+##### `autoDeferOnceEnabled`<sup>Optional</sup> <a name="autoDeferOnceEnabled" id="@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps.property.autoDeferOnceEnabled"></a>
+
+```typescript
+public readonly autoDeferOnceEnabled: boolean;
+```
+
+- *Type:* boolean
+
+Flag that indicates whether MongoDB Cloud should defer all maintenance windows for one week after you enable them.
 
 ---
 
@@ -629,6 +617,18 @@ public readonly profile: string;
 The profile is defined in AWS Secret manager.
 
 See [Secret Manager Profile setup](../../../examples/profile-secret.yaml)
+
+---
+
+##### `projectId`<sup>Optional</sup> <a name="projectId" id="@mongodbatlas-awscdk/maintenance-window.CfnMaintenanceWindowProps.property.projectId"></a>
+
+```typescript
+public readonly projectId: string;
+```
+
+- *Type:* string
+
+Unique 24-hexadecimal digit string that identifies your project.
 
 ---
 

--- a/cdk/cdk-resources/maintenance-window/src/index.ts
+++ b/cdk/cdk-resources/maintenance-window/src/index.ts
@@ -16,6 +16,13 @@ export interface CfnMaintenanceWindowProps {
   readonly profile?: string;
 
   /**
+   * Flag that indicates whether MongoDB Cloud should defer all maintenance windows for one week after you enable them.
+   *
+   * @schema CfnMaintenanceWindowProps#AutoDeferOnceEnabled
+   */
+  readonly autoDeferOnceEnabled?: boolean;
+
+  /**
    * One-based integer that represents the day of the week that the maintenance window starts.
    *
    * | Value | Day of Week |
@@ -32,6 +39,13 @@ export interface CfnMaintenanceWindowProps {
    * @schema CfnMaintenanceWindowProps#DayOfWeek
    */
   readonly dayOfWeek?: number;
+
+  /**
+   * Unique 24-hexadecimal digit string that identifies your project.
+   *
+   * @schema CfnMaintenanceWindowProps#ProjectId
+   */
+  readonly projectId?: string;
 
   /**
    * Zero-based integer that represents the hour of the of the day that the maintenance window starts according to a 24-hour clock. Use `0` for midnight and `12` for noon.
@@ -57,7 +71,9 @@ export function toJson_CfnMaintenanceWindowProps(obj: CfnMaintenanceWindowProps 
   if (obj === undefined) { return undefined; }
   const result = {
     'Profile': obj.profile,
+    'AutoDeferOnceEnabled': obj.autoDeferOnceEnabled,
     'DayOfWeek': obj.dayOfWeek,
+    'ProjectId': obj.projectId,
     'HourOfDay': obj.hourOfDay,
     'StartASAP': obj.startAsap,
   };
@@ -84,14 +100,6 @@ export class CfnMaintenanceWindow extends cdk.CfnResource {
    */
   public readonly props: CfnMaintenanceWindowProps;
 
-  /**
-   * Attribute `MongoDB::Atlas::MaintenanceWindow.ProjectId`
-   */
-  public readonly attrProjectId: string;
-  /**
-   * Attribute `MongoDB::Atlas::MaintenanceWindow.AutoDeferOnceEnabled`
-   */
-  public readonly attrAutoDeferOnceEnabled: cdk.IResolvable;
 
   /**
    * Create a new `MongoDB::Atlas::MaintenanceWindow`.
@@ -105,7 +113,5 @@ export class CfnMaintenanceWindow extends cdk.CfnResource {
 
     this.props = props;
 
-    this.attrProjectId = cdk.Token.asString(this.getAtt('ProjectId'));
-    this.attrAutoDeferOnceEnabled = this.getAtt('AutoDeferOnceEnabled');
   }
 }

--- a/cfn-resources/maintenance-window/cmd/resource/resource.go
+++ b/cfn-resources/maintenance-window/cmd/resource/resource.go
@@ -61,6 +61,12 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
 		return *pe, nil
 	}
+
+	maintenanceWindow, _ := get(client, *currentModel)
+	if maintenanceWindow != nil {
+		return progress_events.GetFailedEventByCode("resource already exists", cloudformation.HandlerErrorCodeAlreadyExists), nil
+	}
+
 	var res *mongodbatlas.Response
 
 	atlasModel := currentModel.toAtlasModel()

--- a/cfn-resources/maintenance-window/docs/README.md
+++ b/cfn-resources/maintenance-window/docs/README.md
@@ -13,7 +13,9 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Type" : "MongoDB::Atlas::MaintenanceWindow",
     "Properties" : {
         "<a href="#profile" title="Profile">Profile</a>" : <i>String</i>,
+        "<a href="#autodeferonceenabled" title="AutoDeferOnceEnabled">AutoDeferOnceEnabled</a>" : <i>Boolean</i>,
         "<a href="#dayofweek" title="DayOfWeek">DayOfWeek</a>" : <i>Integer</i>,
+        "<a href="#projectid" title="ProjectId">ProjectId</a>" : <i>String</i>,
         "<a href="#hourofday" title="HourOfDay">HourOfDay</a>" : <i>Integer</i>,
         "<a href="#startasap" title="StartASAP">StartASAP</a>" : <i>Boolean</i>
     }
@@ -26,7 +28,9 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Type: MongoDB::Atlas::MaintenanceWindow
 Properties:
     <a href="#profile" title="Profile">Profile</a>: <i>String</i>
+    <a href="#autodeferonceenabled" title="AutoDeferOnceEnabled">AutoDeferOnceEnabled</a>: <i>Boolean</i>
     <a href="#dayofweek" title="DayOfWeek">DayOfWeek</a>: <i>Integer</i>
+    <a href="#projectid" title="ProjectId">ProjectId</a>: <i>String</i>
     <a href="#hourofday" title="HourOfDay">HourOfDay</a>: <i>Integer</i>
     <a href="#startasap" title="StartASAP">StartASAP</a>: <i>Boolean</i>
 </pre>
@@ -40,6 +44,16 @@ The profile is defined in AWS Secret manager. See [Secret Manager Profile setup]
 _Required_: No
 
 _Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### AutoDeferOnceEnabled
+
+Flag that indicates whether MongoDB Cloud should defer all maintenance windows for one week after you enable them.
+
+_Required_: No
+
+_Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -64,6 +78,22 @@ _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+#### ProjectId
+
+Unique 24-hexadecimal digit string that identifies your project.
+
+_Required_: No
+
+_Type_: String
+
+_Minimum Length_: <code>24</code>
+
+_Maximum Length_: <code>24</code>
+
+_Pattern_: <code>^([a-f0-9]{24})$</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
 #### HourOfDay
 
 Zero-based integer that represents the hour of the of the day that the maintenance window starts according to a 24-hour clock. Use `0` for midnight and `12` for noon.
@@ -83,24 +113,4 @@ _Required_: No
 _Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-## Return Values
-
-### Ref
-
-When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the ProjectId.
-
-### Fn::GetAtt
-
-The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
-
-For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
-
-#### ProjectId
-
-Unique 24-hexadecimal digit string that identifies your project.
-
-#### AutoDeferOnceEnabled
-
-Flag that indicates whether MongoDB Cloud should defer all maintenance windows for one week after you enable them.
 

--- a/cfn-resources/maintenance-window/mongodb-atlas-maintenancewindow.json
+++ b/cfn-resources/maintenance-window/mongodb-atlas-maintenancewindow.json
@@ -23,7 +23,7 @@
       ]
     }
   },
-  "primaryIdentifier": ["/properties/ProjectId"],
+  "primaryIdentifier": ["/properties/ProjectId", "/properties/Profile"],
   "properties": {
     "Profile": {
       "type": "string",
@@ -54,9 +54,9 @@
       "description": "Flag that indicates whether MongoDB Cloud starts the maintenance window immediately upon receiving this request. To start the maintenance window immediately for your project, MongoDB Cloud must have maintenance scheduled and you must set a maintenance window. This flag resets to `false` after MongoDB Cloud completes maintenance."
     }
   },
-  "readOnlyProperties": [
-    "/properties/ProjectId",
-    "/properties/AutoDeferOnceEnabled"
+  "createOnlyProperties": [
+    "/properties/Profile",
+    "/properties/ProjectId"
   ],
   "required": ["HourOfDay"],
   "typeName": "MongoDB::Atlas::MaintenanceWindow",


### PR DESCRIPTION
## Description

The next issues were fixed for Maintenance Window:

- ProjectId, AutoDeferOnceEnabled , were defined as readonly, making them inaccessible when generating the CDK
- Profile was not defined as PrimaryIdentifier, preventing the property to reach the READ


Link to any related issue(s): 

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

