### PR TITLE
INTMDB-682: update Dpendency-review to run only on pull requests

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -44,6 +44,7 @@ jobs:
         shell: bash
   dependency-review:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

This is a follow-up PR of https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/430 where I merged all the code health checks into a single workflow. After merging my PR, the `dependency-review job` failed
 on the push (see [7855956474](https://github.com/mongodb/mongodbatlas-cloudformation-resources/actions/runs/4471258467/jobs/7855956474)). The reason is that the action can be run only on pull requests. 

This PR fixes the workflow.


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

