### PR TITLE
INTMDB-688: [CFN-PI] Add Manual QA for alert-configuration

### DIFF
--- a/MANUALQA.md
+++ b/MANUALQA.md
@@ -8,6 +8,7 @@
  - Ensure [AWS CLI](https://aws.amazon.com/cli/), [CFN CLI](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html), [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) are installed and configured correctly for your AWS account
  - Configure an Atlas profile secret in AWS account with your API keys. Refer [README](../../../README.md) for more information on how to do this
  - Have Docker running on your machine
+ - Refer to the prerequisites for your resource in the `cfn-resources/[resource-folder]/test`
 
 ### Contract tests
    - Run the following command to build the resource and start AWS SAM

--- a/MANUALQA.md
+++ b/MANUALQA.md
@@ -1,0 +1,57 @@
+# Manual QA
+
+
+## Steps
+
+### Prerequisites
+ - Install [AtlasCLI](https://www.mongodb.com/docs/atlas/cli/stable/install-atlas-cli/) and [configure the default profile](https://www.mongodb.com/docs/atlas/cli/stable/connect-atlas-cli/#select-a-connection-method) on your machine as the scripts use Atlas CLI
+ - Ensure [AWS CLI](https://aws.amazon.com/cli/), [CFN CLI](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html), [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) are installed and configured correctly for your AWS account
+ - Configure an Atlas profile secret in AWS account with your API keys. Refer [README](../../../README.md) for more information on how to do this
+ - Have Docker running on your machine
+
+### Contract tests
+   - Run the following command to build the resource and start AWS SAM
+```bash
+   cd cfn-resources/[resource-folder] && make build && sam local start-lambda --skip-pull-image
+```
+
+   - Open a new terminal session
+   - Generate the cfn test inputs file and required Atlas resources:
+```bash
+   ./../../cfn-testing-helper.sh <resource-folder>
+```
+   - Run cfn test
+```bash
+    cd cfn-resources/[resource-folder]
+    cfn test --function-name TestEntrypoint --verbose 
+```
+### Testing the resource in a CFN stack
+- Publish the resource to the AWS Private registry
+```bash
+cfn submit --set-default
+```
+### Create a stack
+- Ensure all steps above are complete
+- Getting test parameters: 
+  - Option 1: Re-use params from `cfn-resources/[resource-folder]/inputs/inputs_1_create.template.json` generated as part of prerequisites
+  - Option 2: Run again  `cfn-testing-helper` to create new parameters.  This will create some required resources for you in your configured Atlas account
+- Update template in `examples/[resource-folder]/[resource-name].json` with your changes (if any) AND required params from last step
+- Login to AWS account -> CloudFormation -> click on Create Stack dropdown and select (with new resources)
+- Upload the updated template: You can either upload the updated file OR select Create template in Designer
+- Add a Stack name on Specify stack details page and provide any required parameters for your resource, if any
+- Click on Next and follow UI prompts to configure stack options if needed. Finally, click on Submit. Your stack should now be created and resource creation IN_PROGRESS
+
+### Update the stack
+- In AWS CloudFormation, navigate to your stack and click on Update. You can use the current template or edit in designer
+- Update any parameters or outputs for your template
+- Follow UI prompts and Submit
+
+### Delete the stack
+- In AWS CloudFormation, navigate to your stack and click on Delete
+
+### Success criteria when testing the resource
+- Refer to the success criteria for your resource first in the `cfn-resources/[resource-folder]/test`.
+- Stack Outputs should show required data correctly based on the template
+- Create: Stack should complete successfully and resource should be created and correctly configured in Atlas account as per template
+- Update: Stack should complete successfully and resource should be updated and correctly configured in Atlas account as per template
+- Delete: Stack should complete successfully and resource should be deleted from your Atlas account

--- a/MANUALQA.md
+++ b/MANUALQA.md
@@ -34,7 +34,7 @@ cfn submit --set-default
 ### Create a stack
 - Ensure all steps above are complete
 - Getting test parameters: 
-  - Option 1: Re-use params from `cfn-resources/[resource-folder]/inputs/inputs_1_create.template.json` generated as part of prerequisites
+  - Option 1 [Recommended]: Re-use params from `cfn-resources/[resource-folder]/inputs/inputs_1_create.template.json` generated as part of prerequisites
   - Option 2: Run again  `cfn-testing-helper` to create new parameters.  This will create some required resources for you in your configured Atlas account
 - Update template in `examples/[resource-folder]/[resource-name].json` with your changes (if any) AND required params from last step
 - Login to AWS account -> CloudFormation -> click on Create Stack dropdown and select (with new resources)

--- a/TESTING.md.md
+++ b/TESTING.md.md
@@ -1,16 +1,19 @@
-# Manual QA
+# Testing
+This file contains the steps to follow to test any changes to the CFN resources.
 
 
-## Steps
+## Manual QA
 
-### Prerequisites
+### Steps
+
+#### Prerequisites
  - Install [AtlasCLI](https://www.mongodb.com/docs/atlas/cli/stable/install-atlas-cli/) and [configure the default profile](https://www.mongodb.com/docs/atlas/cli/stable/connect-atlas-cli/#select-a-connection-method) on your machine as the scripts use Atlas CLI
  - Ensure [AWS CLI](https://aws.amazon.com/cli/), [CFN CLI](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html), [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) are installed and configured correctly for your AWS account
  - Configure an Atlas profile secret in AWS account with your API keys. Refer [README](../../../README.md) for more information on how to do this
  - Have Docker running on your machine
  - Refer to the prerequisites for your resource in the `cfn-resources/[resource-folder]/test`
 
-### Contract tests
+#### Contract tests
    - Run the following command to build the resource and start AWS SAM
 ```bash
    cd cfn-resources/[resource-folder] && make build && sam local start-lambda --skip-pull-image
@@ -26,12 +29,12 @@
     cd cfn-resources/[resource-folder]
     cfn test --function-name TestEntrypoint --verbose 
 ```
-### Testing the resource in a CFN stack
+#### Testing the resource in a CFN stack
 - Publish the resource to the AWS Private registry
 ```bash
 cfn submit --set-default
 ```
-### Create a stack
+#### Create a stack
 - Ensure all steps above are complete
 - Getting test parameters: 
   - Option 1 [Recommended]: Re-use params from `cfn-resources/[resource-folder]/inputs/inputs_1_create.template.json` generated as part of prerequisites
@@ -42,12 +45,12 @@ cfn submit --set-default
 - Add a Stack name on Specify stack details page and provide any required parameters for your resource, if any
 - Click on Next and follow UI prompts to configure stack options if needed. Finally, click on Submit. Your stack should now be created and resource creation IN_PROGRESS
 
-### Update the stack
+#### Update the stack
 - In AWS CloudFormation, navigate to your stack and click on Update. You can use the current template or edit in designer
 - Update any parameters or outputs for your template
 - Follow UI prompts and Submit
 
-### Delete the stack
+#### Delete the stack
 - In AWS CloudFormation, navigate to your stack and click on Delete
 
 ### Success criteria when testing the resource

--- a/TESTING.md.md
+++ b/TESTING.md.md
@@ -4,14 +4,15 @@ This file contains the steps to follow to test any changes to the CFN resources.
 
 ## Manual QA
 
-### Steps
-
-#### Prerequisites
+### Prerequisites
  - Install [AtlasCLI](https://www.mongodb.com/docs/atlas/cli/stable/install-atlas-cli/) and [configure the default profile](https://www.mongodb.com/docs/atlas/cli/stable/connect-atlas-cli/#select-a-connection-method) on your machine as the scripts use Atlas CLI
  - Ensure [AWS CLI](https://aws.amazon.com/cli/), [CFN CLI](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html), [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) are installed and configured correctly for your AWS account
  - Configure an Atlas profile secret in AWS account with your API keys. Refer [README](../../../README.md) for more information on how to do this
  - Have Docker running on your machine
  - Refer to the prerequisites for your resource in the `cfn-resources/[resource-folder]/test`
+
+
+### Steps
 
 #### Contract tests
    - Run the following command to build the resource and start AWS SAM
@@ -29,13 +30,15 @@ This file contains the steps to follow to test any changes to the CFN resources.
     cd cfn-resources/[resource-folder]
     cfn test --function-name TestEntrypoint --verbose 
 ```
+
 #### Testing the resource in a CFN stack
-- Publish the resource to the AWS Private registry
-```bash
-cfn submit --set-default
-```
-#### Create a stack
+
+##### Create a stack
 - Ensure all steps above are complete
+- Publish the resource to the AWS Private registry
+  ```bash
+  cfn submit --set-default
+  ```
 - Getting test parameters: 
   - Option 1 [Recommended]: Re-use params from `cfn-resources/[resource-folder]/inputs/inputs_1_create.template.json` generated as part of prerequisites
   - Option 2: Run again  `cfn-testing-helper` to create new parameters.  This will create some required resources for you in your configured Atlas account
@@ -43,14 +46,14 @@ cfn submit --set-default
 - Login to AWS account -> CloudFormation -> click on Create Stack dropdown and select (with new resources)
 - Upload the updated template: You can either upload the updated file OR select Create template in Designer
 - Add a Stack name on Specify stack details page and provide any required parameters for your resource, if any
-- Click on Next and follow UI prompts to configure stack options if needed. Finally, click on Submit. Your stack should now be created and resource creation IN_PROGRESS
+- Click on Next and follow UI prompts to configure stack options if needed. Finally, click on Submit. Your stack should now be created and resource creation `IN_PROGRESS`
 
-#### Update the stack
+##### Update the stack
 - In AWS CloudFormation, navigate to your stack and click on Update. You can use the current template or edit in designer
 - Update any parameters or outputs for your template
 - Follow UI prompts and Submit
 
-#### Delete the stack
+##### Delete the stack
 - In AWS CloudFormation, navigate to your stack and click on Delete
 
 ### Success criteria when testing the resource

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -5,7 +5,8 @@ The following components use this resource and are potentially impacted by any c
  - Alert Configuration L1 CDK constructor
 
 
-## Resources needed to run the manual QA
+## Prerequisites 
+### Resources needed to run the manual QA
 - Atlas Project
 
 All resources are created as part of `cfn-testing-helper.sh`

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -1,6 +1,7 @@
 # Alert Configurations 
 
 ## Impact 
+The following components use this resource and are potentially impacted by any changes. They should also be validated to ensure the changes do not cause a regression.
  - Alert Configuration L1 CDK constructor
 
 ## Manual QA

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -12,7 +12,7 @@ The following components use this resource and are potentially impacted by any c
 All resources are created as part of `cfn-testing-helper.sh`
 
 ## Manual QA
-Please, follows the steps in [MANUALQA.md](../../../MANUALQA.md).
+Please, follows the steps in [TESTING.md](../../../TESTING.md.md).
 
 
 ### Success criteria when testing the resource

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -1,9 +1,9 @@
-## Alert Configurations 
+# Alert Configurations 
 
-### Impact 
+## Impact 
  - Alert Configuration L1 CDK constructor
 
-### Manual QA
+## Manual QA
 
 #### Resources needed to run the manual QA
 - Atlas Project
@@ -67,6 +67,6 @@ cfn submit --set-default
 - Delete: Stack should complete successfully and resource should be deleted from your Atlas account
 
 
-### Important Links
+## Important Links
 - [API Documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Alert-Configurations/operation/listAlertConfigurations)
 - [Resource Usage Documentation](https://www.mongodb.com/docs/atlas/configure-alerts/#configure-an-alert)

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -62,9 +62,9 @@ cfn submit --set-default
 - Alert Settings for the respective Project in Atlas should be correctly configured:
 ![image](https://user-images.githubusercontent.com/5663078/226870968-9ef8ae46-b0cf-462b-ac62-7229d2d79ac0.png)
 - Stack Outputs should show required data correctly based on the template
-- Create - Stack should complete successfully and resource should be created and correctly configured in Atlas account as per template
-- Update - Stack should complete successfully and resource should be updated and correctly configured in Atlas account as per template
-- Delete - Stack should complete successfully and resource should be deleted from your Atlas account
+- Create: Stack should complete successfully and resource should be created and correctly configured in Atlas account as per template
+- Update: Stack should complete successfully and resource should be updated and correctly configured in Atlas account as per template
+- Delete: Stack should complete successfully and resource should be deleted from your Atlas account
 
 
 ### Important Links

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -39,7 +39,7 @@ All resources are created as part of `cfn-testing-helper.sh`
 ```bash
 cfn submit --set-default
 ```
-##### Create a stack
+#### Create a stack
 - Ensure all steps above are complete
 - Getting test parameters: 
   - Option 1: Re-use params from cfn-resources/alert-configuration/inputs/inputs_1_create.template.json generated as part of prerequisites

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -1,0 +1,72 @@
+## Alert Configurations 
+
+### Impact 
+ - Alert Configuration L1 CDK constructor
+
+### Manual QA
+
+#### Resources needed to run the manual QA
+- Atlas Project
+
+All resources are created as part of `cfn-testing-helper.sh`
+
+### Steps
+
+#### Prerequisites
+ - Configure Atlas default profile on your machine as the scripts use Atlas CLI.
+ - Ensure aws and cfn CLI are installed and configured correctly for your AWS account.
+ - Configure an Atlas profile secret in AWS account with your API keys. Refer README for more information on how to do this.
+ - Have Docker running on your machine.
+
+#### Contract tests
+   - Run the following command to build the resource and start AWS SAM
+```bash
+   cd cfn-resources/alert-configuration && make build && sam local start-lambda --skip-pull-image
+```
+
+   - Open a new terminal session
+   - Generate the cfn test inputs file and required Atlas resources:
+```bash
+   ./../../cfn-testing-helper.sh <resource-folder>
+```
+   - Run cfn test
+```bash
+    cd cfn-resources/alert-configuration 
+    cfn test --function-name TestEntrypoint --verbose 
+```
+#### Testing the resource in a CFN stack
+- Publish the resource to the AWS Private registry
+```bash
+cfn submit --set-default
+```
+##### Create a stack
+- Ensure all steps above are complete
+- Getting test parameters: 
+  - Option 1: Re-use params from cfn-resources/alert-configuration/inputs/inputs_1_create.template.json generated as part of prerequisites
+  - Option 2: Run again  `cfn-testing-helper` to create new parameters.  This will create some required resources for you in your configured Atlas account
+- Update template in [examples/alert-configuration](../../../examples/alert-configuration/alert-configuration.json) with your changes (if any) AND required params from last step
+- Login to AWS account -> CloudFormation -> click on Create Stack dropdown and select (with new resources)
+- Upload the updated template: You can either upload the updated file OR select Create template in Designer
+- Add a Stack name on Specify stack details page and provide any required parameters for your resource, if any
+- Click on Next and follow UI prompts to configure stack options if needed. Finally click on Submit. Your stack should now be created and resource creation IN_PROGRESS
+
+#### Update the stack
+- In AWS CloudFormation, navigate to your stack and click on Update. You can use the current template or edit in designer
+- Update any parameters or outputs for your template
+- Follow UI prompts and Submit
+
+#### Delete the stack
+- In AWS CloudFormation, navigate to your stack and click on Delete
+
+### Success criteria when testing the resource
+- Alert Settings for the respective Project in Atlas should be correctly configured:
+![image](https://user-images.githubusercontent.com/5663078/226870968-9ef8ae46-b0cf-462b-ac62-7229d2d79ac0.png)
+- Stack Outputs should show required data correctly based on the template
+- Create - Stack should complete successfully and resource should be created and correctly configured in Atlas account as per template
+- Update - Stack should complete successfully and resource should be updated and correctly configured in Atlas account as per template
+- Delete - Stack should complete successfully and resource should be deleted from your Atlas account
+
+
+### Important Links
+- [API Documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Alert-Configurations/operation/listAlertConfigurations)
+- [Resource Usage Documentation](https://www.mongodb.com/docs/atlas/configure-alerts/#configure-an-alert)

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -13,10 +13,10 @@ All resources are created as part of `cfn-testing-helper.sh`
 ### Steps
 
 #### Prerequisites
- - Configure Atlas default profile on your machine as the scripts use Atlas CLI.
- - Ensure aws and cfn CLI are installed and configured correctly for your AWS account.
- - Configure an Atlas profile secret in AWS account with your API keys. Refer [README](../../../README.md) for more information on how to do this.
- - Have Docker running on your machine.
+ - Install [AtlasCLI](https://www.mongodb.com/docs/atlas/cli/stable/install-atlas-cli/) and [configure the default profile](https://www.mongodb.com/docs/atlas/cli/stable/connect-atlas-cli/#select-a-connection-method) on your machine as the scripts use Atlas CLI
+ - Ensure [AWS CLI](https://aws.amazon.com/cli/), [CFN CLI](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html), [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) are installed and configured correctly for your AWS account
+ - Configure an Atlas profile secret in AWS account with your API keys. Refer [README](../../../README.md) for more information on how to do this
+ - Have Docker running on your machine
 
 #### Contract tests
    - Run the following command to build the resource and start AWS SAM

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -4,69 +4,19 @@
 The following components use this resource and are potentially impacted by any changes. They should also be validated to ensure the changes do not cause a regression.
  - Alert Configuration L1 CDK constructor
 
-## Manual QA
 
-#### Resources needed to run the manual QA
+## Resources needed to run the manual QA
 - Atlas Project
 
 All resources are created as part of `cfn-testing-helper.sh`
 
-### Steps
+## Manual QA
+Please, follows the steps in [MANUALQA.md](../../../MANUALQA.md).
 
-#### Prerequisites
- - Install [AtlasCLI](https://www.mongodb.com/docs/atlas/cli/stable/install-atlas-cli/) and [configure the default profile](https://www.mongodb.com/docs/atlas/cli/stable/connect-atlas-cli/#select-a-connection-method) on your machine as the scripts use Atlas CLI
- - Ensure [AWS CLI](https://aws.amazon.com/cli/), [CFN CLI](https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/what-is-cloudformation-cli.html), [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) are installed and configured correctly for your AWS account
- - Configure an Atlas profile secret in AWS account with your API keys. Refer [README](../../../README.md) for more information on how to do this
- - Have Docker running on your machine
-
-#### Contract tests
-   - Run the following command to build the resource and start AWS SAM
-```bash
-   cd cfn-resources/alert-configuration && make build && sam local start-lambda --skip-pull-image
-```
-
-   - Open a new terminal session
-   - Generate the cfn test inputs file and required Atlas resources:
-```bash
-   ./../../cfn-testing-helper.sh <resource-folder>
-```
-   - Run cfn test
-```bash
-    cd cfn-resources/alert-configuration 
-    cfn test --function-name TestEntrypoint --verbose 
-```
-#### Testing the resource in a CFN stack
-- Publish the resource to the AWS Private registry
-```bash
-cfn submit --set-default
-```
-#### Create a stack
-- Ensure all steps above are complete
-- Getting test parameters: 
-  - Option 1: Re-use params from cfn-resources/alert-configuration/inputs/inputs_1_create.template.json generated as part of prerequisites
-  - Option 2: Run again  `cfn-testing-helper` to create new parameters.  This will create some required resources for you in your configured Atlas account
-- Update template in [examples/alert-configuration](../../../examples/alert-configuration/alert-configuration.json) with your changes (if any) AND required params from last step
-- Login to AWS account -> CloudFormation -> click on Create Stack dropdown and select (with new resources)
-- Upload the updated template: You can either upload the updated file OR select Create template in Designer
-- Add a Stack name on Specify stack details page and provide any required parameters for your resource, if any
-- Click on Next and follow UI prompts to configure stack options if needed. Finally click on Submit. Your stack should now be created and resource creation IN_PROGRESS
-
-#### Update the stack
-- In AWS CloudFormation, navigate to your stack and click on Update. You can use the current template or edit in designer
-- Update any parameters or outputs for your template
-- Follow UI prompts and Submit
-
-#### Delete the stack
-- In AWS CloudFormation, navigate to your stack and click on Delete
 
 ### Success criteria when testing the resource
 - Alert Settings for the respective Project in Atlas should be correctly configured:
 ![image](https://user-images.githubusercontent.com/5663078/226870968-9ef8ae46-b0cf-462b-ac62-7229d2d79ac0.png)
-- Stack Outputs should show required data correctly based on the template
-- Create: Stack should complete successfully and resource should be created and correctly configured in Atlas account as per template
-- Update: Stack should complete successfully and resource should be updated and correctly configured in Atlas account as per template
-- Delete: Stack should complete successfully and resource should be deleted from your Atlas account
-
 
 ## Important Links
 - [API Documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Alert-Configurations/operation/listAlertConfigurations)

--- a/cfn-resources/alert-configuration/test/README.md
+++ b/cfn-resources/alert-configuration/test/README.md
@@ -15,7 +15,7 @@ All resources are created as part of `cfn-testing-helper.sh`
 #### Prerequisites
  - Configure Atlas default profile on your machine as the scripts use Atlas CLI.
  - Ensure aws and cfn CLI are installed and configured correctly for your AWS account.
- - Configure an Atlas profile secret in AWS account with your API keys. Refer README for more information on how to do this.
+ - Configure an Atlas profile secret in AWS account with your API keys. Refer [README](../../../README.md) for more information on how to do this.
  - Have Docker running on your machine.
 
 #### Contract tests


### PR DESCRIPTION
## Description

This PR adds the [README.md](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/INTMDB-688/cfn-resources/alert-configuration/test) to the test folder of alert-configuration



## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

