### PR TITLE
INTMDB-695: [CFN-PI] Quickstart VPC peering does not provide an iam role to use to execute the template

### DIFF
--- a/examples/quickstart-mongodb-atlas/execution-role.yaml
+++ b/examples/quickstart-mongodb-atlas/execution-role.yaml
@@ -1,3 +1,4 @@
+# This Template creates the IAM role to use to run the quickstart template on a CFN stack
 Resources:
  AtlasQuickstartIAMRole:
   Type: 'AWS::IAM::Role'

--- a/examples/quickstart-mongodb-atlas/execution-role.yaml
+++ b/examples/quickstart-mongodb-atlas/execution-role.yaml
@@ -1,0 +1,47 @@
+Resources:
+ AtlasQuickstartIAMRole:
+  Type: 'AWS::IAM::Role'
+  Properties:
+   AssumeRolePolicyDocument:
+    Version: '2012-10-17'
+    Statement:
+    - Effect: Allow
+      Principal:
+       Service:
+       - "lambda.amazonaws.com"
+       - "resources.cloudformation.amazonaws.com"
+       - "cloudformation.amazonaws.com"
+      Action: sts:AssumeRole
+   Path: /
+   Policies:
+   - PolicyName: AtlasQuickstartPolicy
+     PolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+      - Effect: Allow
+        Action:
+        - iam:PassRole
+        - iam:DeleteRolePolicy
+        - iam:AttachRolePolicy
+        - iam:CreateRole
+        - iam:PutRolePolicy
+        - iam:DeleteRole
+        - iam:GetRole
+        - iam:GetRolePolicy
+        Resource: '*'
+      - Effect: Allow
+        Action: cloudformation:*
+        Resource: '*'
+      - Effect: Allow
+        Action: ec2:*
+        Resource: '*'
+      - Effect: Allow
+        Action:
+        - secretsmanager:CreateSecret
+        - secretsmanager:DeleteSecret
+        - secretsmanager:DescribeSecret
+        - secretsmanager:GetSecretValue
+        - secretsmanager:ListSecrets
+        - secretsmanager:PutSecretValue
+        - secretsmanager:TagResource
+        Resource: '*'

--- a/examples/quickstart-mongodb-atlas/execution-role.yaml
+++ b/examples/quickstart-mongodb-atlas/execution-role.yaml
@@ -29,6 +29,7 @@ Resources:
         - iam:DeleteRole
         - iam:GetRole
         - iam:GetRolePolicy
+        - iam:DetachRolePolicy
         Resource: '*'
       - Effect: Allow
         Action: cloudformation:*


### PR DESCRIPTION
## Description

This PR adds the `execute-role.yaml` template to use to create the IAM role to run the quickstart template

![Screenshot 2023-03-23 at 09 14 19](https://user-images.githubusercontent.com/5663078/227157031-d96b26d8-74f4-49a9-a63c-a2ef237f7390.png)


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

**Next Steps:**

- Adding the same template in the aws repository
- Update the documentation to mention this template