### PR TITLE
CLOUDP-167925: upgrade client to v0.23.2 which adds support for PrivateEndpoint.srvShardOptimizedConnectionString

### DIFF
--- a/cfn-resources/go.mod
+++ b/cfn-resources/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/rs/xid v1.4.0
 	github.com/spf13/cast v1.5.0
 	github.com/tidwall/pretty v1.2.1
-	go.mongodb.org/atlas v0.23.1
+	go.mongodb.org/atlas v0.23.2
 	go.mongodb.org/realm v0.1.0
 )
 

--- a/cfn-resources/go.sum
+++ b/cfn-resources/go.sum
@@ -80,8 +80,8 @@ github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.mongodb.org/atlas v0.12.0/go.mod h1:wVCnHcm/7/IfTjEB6K8K35PLG70yGz8BdkRwX0oK9/M=
-go.mongodb.org/atlas v0.23.1 h1:nQjqIzAizf4uaD7lECpVF6kldnZvJnmCTDrqkS4hVyc=
-go.mongodb.org/atlas v0.23.1/go.mod h1:XTjsxWgoOSwaZrQUvhTEuwjymxnF0r12RPibZuW1Uts=
+go.mongodb.org/atlas v0.23.2 h1:UvaDoESx+B2mSjT3PRk8Jdyl6d45z5nMn/40z45ZQyQ=
+go.mongodb.org/atlas v0.23.2/go.mod h1:L4BKwVx/OeEhOVjCSdgo90KJm4469iv7ZLzQms/EPTg=
 go.mongodb.org/realm v0.1.0 h1:zJiXyLaZrznQ+Pz947ziSrDKUep39DO4SfA0Fzx8M4M=
 go.mongodb.org/realm v0.1.0/go.mod h1:4Vj6iy+Puo1TDERcoh4XZ+pjtwbOzPpzqy3Cwe8ZmDM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION


## Description

Updating the go client dep to v0.23.2

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

