### PR TITLE
Remove MCLI_ env variables and cleanup READMEs for CFN resources

### DIFF
--- a/cfn-resources/cloud-backup-snapshot/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/cloud-backup-snapshot/test/cfn-test-create-inputs.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2023 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # cfn-test-create-inputs.sh
 #
 # This tool generates json files in the inputs/ for `cfn test`.
@@ -29,7 +43,6 @@ if [ -z "$projectId" ]; then
 	projectId=$(atlas projects create "${projectName}" --output=json | jq -r '.id')
 	echo -e "Cant find project \"${projectName}\"\n"
 fi
-export MCLI_PROJECT_ID=$projectId
 
 atlas clusters create "${clusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --mdbVersion 5.0 --diskSizeGB 10 --output=json
 atlas clusters watch "${clusterName}" --projectId "${projectId}"

--- a/cfn-resources/custom-dns-configuration-cluster-aws/README.md
+++ b/cfn-resources/custom-dns-configuration-cluster-aws/README.md
@@ -16,14 +16,6 @@ sam local start-lambda --skip-pull-image
 ```
 then in another shell:
 ```bash
-#https://www.mongodb.com/docs/mongocli/stable/configure/environment-variables/
-#Set the public API key for commands that interact with your MongoDB service.
-export MCLI_PUBLIC_API_KEY = ""
-#Set the private API key for commands that interact with your MongoDB service.
-export MCLI_PRIVATE_API_KEY=""
-#Sets the project ID for commands that require the --projectId option.
-export MCLI_PROJECT_ID = ""
-
 cd ${repo_root}/cfn-resources/custom-dns-configuration-cluster-aws
 ./test/custom-dns-config-cluster-aws.create-sample-cfn-request.sh > test.request.json
 echo "Sample request:"

--- a/cfn-resources/datalakes/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/datalakes/test/cfn-test-create-inputs.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2023 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # cfn-test-create-inputs.sh
 #
 # This tool generates json files in the inputs/ for `cfn test`.
@@ -30,9 +44,6 @@ if [ -z "$projectId" ]; then
 else
     echo -e "FOUND project \"${projectName}\" with id: ${projectId}\n"
 fi
-
-echo "Check if a project is created $projectId"
-export MCLI_PROJECT_ID=$projectId
 
 clusterName="${projectName}"
 

--- a/cfn-resources/global-cluster-config/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/global-cluster-config/test/cfn-test-create-inputs.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2023 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # cfn-test-create-inputs.sh
 #
 # This tool generates json files in the inputs/ for `cfn test`.
@@ -30,7 +44,6 @@ else
 	echo -e "FOUND project \"${projectName}\" with id: ${projectId}\n"
 fi
 echo -e "=====\nrun this command to clean up\n=====\nmongocli iam projects delete ${projectId} --force\n====="
-export MCLI_PROJECT_ID=$projectId
 
 ClusterName="${projectName}"
 

--- a/cfn-resources/global-cluster-config/test/inputs_1_create.template.json
+++ b/cfn-resources/global-cluster-config/test/inputs_1_create.template.json
@@ -1,9 +1,12 @@
 {
-    "ProjectId": "",
-    "ClusterName": "",
-    "CustomZoneMappings": [{
-        "Location": "IN",
-        "Zone": "Zone 1"
-    }],
-    "RemoveAllZoneMapping": true
+  "ProjectId": "",
+  "ClusterName": "",
+  "CustomZoneMappings": [
+    {
+      "Location": "IN",
+      "Zone": "Zone 1"
+    }
+  ],
+  "RemoveAllZoneMapping": true,
+  "Profile": ""
 }

--- a/cfn-resources/global-cluster-config/test/inputs_1_invalid.template.json
+++ b/cfn-resources/global-cluster-config/test/inputs_1_invalid.template.json
@@ -1,8 +1,11 @@
 {
-    "ProjectId": "",
-    "ClusterName": "",
-    "CustomZoneMappings": [{
-        "Location": "IN",
-        "Zone": "Zone 1"
-    }]
+  "ProjectId": "",
+  "ClusterName": "",
+  "Profile": "",
+  "CustomZoneMappings": [
+    {
+      "Location": "IN",
+      "Zone": "Zone 1"
+    }
+  ]
 }

--- a/cfn-resources/network-container/test/networkcontainer.create-sample-cfn-request.sh
+++ b/cfn-resources/network-container/test/networkcontainer.create-sample-cfn-request.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2023 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # networkcontainer.create-sample-request.sh
 #
 # This tool generates text for a `cfn invoke` request json message.
@@ -11,6 +25,6 @@ set -o pipefail
 if [ "$#" -ne 1 ]; then usage; fi
 if [[ "$*" == help ]]; then usage; fi
 
-jq --arg ProjectId "$MCLI_PROJECT_ID" \
+jq --arg ProjectId "$ATLAS_PROJECT_ID" \
 	'.desiredResourceState.ProjectId?|=$ProjectId' \
 	"$(dirname "$0")/networkcontainer.sample-cfn-request.json"

--- a/cfn-resources/project-invitation/README.md
+++ b/cfn-resources/project-invitation/README.md
@@ -16,14 +16,6 @@ sam local start-lambda --skip-pull-image
 ```
 then in another shell:
 ```bash
-#https://www.mongodb.com/docs/mongocli/stable/configure/environment-variables/
-#Set the public API key for commands that interact with your MongoDB service.
-export MCLI_PUBLIC_API_KEY = ""
-#Set the private API key for commands that interact with your MongoDB service.
-export MCLI_PRIVATE_API_KEY=""
-#Sets the project ID for commands that require the --projectId option.
-export MCLI_PROJECT_ID = ""
-
 cd ${repo_root}/cfn-resources/project-invitation
 ./test/project-invitation.create-sample-cfn-request.sh > test.request.json 
 echo "Sample request:"

--- a/cfn-resources/third-party-integration/README.md
+++ b/cfn-resources/third-party-integration/README.md
@@ -16,14 +16,6 @@ sam local start-lambda --skip-pull-image
 ```
 then in another shell:
 ```bash
-#https://www.mongodb.com/docs/mongocli/stable/configure/environment-variables/
-#Set the public API key for commands that interact with your MongoDB service.
-export MCLI_PUBLIC_API_KEY = ""
-#Set the private API key for commands that interact with your MongoDB service.
-export MCLI_PRIVATE_API_KEY=""
-#Sets the project ID for commands that require the --projectId option.
-export MCLI_PROJECT_ID = ""
-
 cd ${repo_root}/cfn-resources/thirdpartyintegration
 ./test/thirdpartyintegration.create-sample-cfn-request.sh > test.request.json 
 echo "Sample request:"

--- a/cfn-resources/third-party-integration/test/thirdpartyintegration.create-sample-cfn-request.sh
+++ b/cfn-resources/third-party-integration/test/thirdpartyintegration.create-sample-cfn-request.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2023 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # thirdpartyintegration.create-sample-cfn-request.sh
 #
 # This tool generates text for a `cfn invoke` request json message.
@@ -8,6 +22,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-jq --arg ProjectId "$MCLI_PROJECT_ID" \
+jq --arg ProjectId "$ATLAS_PROJECT_ID" \
 	'.desiredResourceState.ProjectId?|=$ProjectId' \
 	"$(dirname "$0")/thirdpartyintegration.sample-cfn-request.json"


### PR DESCRIPTION
## Description

Remove MCLI_ env variables and cleanup READMEs for CFN resources
Link to any related issue(s): 

## Type of change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change works in Atlas

## Further comments

