### PR TITLE
Update cfn-3P-provider-register.yaml

### DIFF
--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -242,6 +242,7 @@ mainSteps:
         - FAULT
         - STOPPED
         - TIMED_OUT
+      timeoutSeconds: 7200
   - name: Check_Build_Status
     action: 'aws:assertAwsResourceProperty'
     inputs:


### PR DESCRIPTION
## Proposed changes

The Cluster resource codebuild was taking 1h 25m, since the aws:waitForAwsResourceProperty has a default timeout of 1 hour, so the automation was failing with a timeout

![image](https://user-images.githubusercontent.com/69170650/229551675-7116a7d5-d426-4fa0-b3c6-6c4bfcaefa37.png)

the timeout was extended to two hours

Link to any related issue(s): 


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

