### PR TITLE
INTMDB-724: Hide key values when using example profile template

### DIFF
--- a/examples/profile-secret.yaml
+++ b/examples/profile-secret.yaml
@@ -9,10 +9,12 @@ Parameters:
     Description: "Your MongoDB Atlas Public API Key"
     Type: String
     Default: "PublicKey"
+    NoEcho: true
   PrivateKey:
     Description: "Your MongoDB Atlas Private API Key"
     Type: String
     Default: "PrivateKey"
+    NoEcho: true
 Resources:
   AtlasApiKeySecret:
     Type: 'AWS::SecretsManager::Secret'


### PR DESCRIPTION
Updating the example template for creating a profile secret to hide the private & public key values in the CFN UI

Example at creation:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/4273411/230136577-5574b3ab-dd7b-425e-a80e-c2ec66f3fe51.png">


Example of stack details:
<img width="1370" alt="image" src="https://user-images.githubusercontent.com/4273411/230136761-a6fcc406-9a88-4d9c-9107-9cf7ccda2c61.png">

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

