### PR TITLE
added connection strings to Cluster CDK

### DIFF
--- a/cdk/cdk-resources/cluster/src/index.ts
+++ b/cdk/cdk-resources/cluster/src/index.ts
@@ -35,13 +35,6 @@ export interface CfnClusterProps {
   readonly clusterType?: string;
 
   /**
-   * Set of connection strings that your applications use to connect to this cluster. Use the parameters in this object to connect your applications to this cluster. See the MongoDB [Connection String URI Format](https://docs.mongodb.com/manual/reference/connection-string/) reference for further details.
-   *
-   * @schema CfnClusterProps#ConnectionStrings
-   */
-  readonly connectionStrings?: ConnectionStrings;
-
-  /**
    * Storage capacity that the host's root volume possesses expressed in gigabytes. Increase this number to add capacity. MongoDB Cloud requires this parameter if you set replicationSpecs. If you specify a disk size below the minimum (10 GB), this parameter defaults to the minimum disk size value. Storage charge calculations depend on whether you choose the default value or a custom value. The maximum value for disk storage cannot exceed 50 times the maximum RAM for the selected cluster. If you require more storage space, consider upgrading your cluster to a higher tier.
    *
    * @schema CfnClusterProps#DiskSizeGB
@@ -145,7 +138,6 @@ export function toJson_CfnClusterProps(obj: CfnClusterProps | undefined): Record
     'BackupEnabled': obj.backupEnabled,
     'BiConnector': toJson_CfnClusterPropsBiConnector(obj.biConnector),
     'ClusterType': obj.clusterType,
-    'ConnectionStrings': toJson_ConnectionStrings(obj.connectionStrings),
     'DiskSizeGB': obj.diskSizeGb,
     'EncryptionAtRestProvider': obj.encryptionAtRestProvider,
     'Profile': obj.profile,
@@ -832,7 +824,7 @@ export class CfnCluster extends cdk.CfnResource {
   /**
   * The CloudFormation resource type name for this resource class.
   */
-  public static readonly CFN_RESOURCE_TYPE_NAME = 'MongoDB::Atlas::Cluster';
+  public static readonly CFN_RESOURCE_TYPE_NAME = "MongoDB::Atlas::Cluster";
 
   /**
    * Resource props.
@@ -857,6 +849,11 @@ export class CfnCluster extends cdk.CfnResource {
   public readonly attrId: string;
 
   /**
+   * Attribute `MongoDB::Atlas::Cluster.ConnectionStrings`
+   */
+  public readonly connectionStrings: ConnectionStrings;
+
+  /**
    * Create a new `MongoDB::Atlas::Cluster`.
    *
    * @param scope - scope in which this resource is defined
@@ -868,9 +865,18 @@ export class CfnCluster extends cdk.CfnResource {
 
     this.props = props;
 
+    const connStringsStandard = cdk.Token.asString(this.getAtt('ConnectionStrings.Standard'));
+    const connStringsStandardSrv = cdk.Token.asString(this.getAtt('ConnectionStrings.StandardSrv'));
+    const connStringsPrivate = cdk.Token.asString(this.getAtt('ConnectionStrings.Private'));
+    const connStringsPrivateSrv = cdk.Token.asString(this.getAtt('ConnectionStrings.PrivateSrv'));
+
     this.attrStateName = cdk.Token.asString(this.getAtt('StateName'));
     this.attrMongoDBVersion = cdk.Token.asString(this.getAtt('MongoDBVersion'));
     this.attrCreatedDate = cdk.Token.asString(this.getAtt('CreatedDate'));
     this.attrId = cdk.Token.asString(this.getAtt('Id'));
+    this.connectionStrings = {standard : connStringsStandard ,
+      standardSrv : connStringsStandardSrv,
+      private : connStringsPrivate,
+      privateSrv : connStringsPrivateSrv }
   }
 }

--- a/cfn-resources/cluster/docs/README.md
+++ b/cfn-resources/cluster/docs/README.md
@@ -270,6 +270,10 @@ Returns the <code>Private</code> value.
 
 Returns the <code>PrivateSrv</code> value.
 
+#### ConnectionStrings
+
+Collection of Uniform Resource Locators that point to the MongoDB database.
+
 #### StateName
 
 Current state of the cluster.


### PR DESCRIPTION
## Proposed changes

The Cluster CDK L1, was modified to be able to output the connection strings:

the next properties were exposed by the CfnCluster.connectionStrings

- Standard
- StandardSrv
- Private
- PrivateSrv


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

