### PR TITLE
DOCSP-29454 Clean up teams resource docs

### DIFF
--- a/cfn-resources/teams/README.md
+++ b/cfn-resources/teams/README.md
@@ -3,40 +3,22 @@
 ## Description
 Returns, adds, edits, or removes teams to Atlas Organization and Atlas Project (if specified).
 
-## Attributes & Parameters
+## Attributes and Parameters
 
-Please consult the [Resource Docs](docs/README.md)
-
-## Unit Testing Locally
-
-The local tests are integrated with the AWS `sam local` and `cfn invoke` tooling features:
-
-```
-sam local start-lambda --skip-pull-image
-```
-then in another shell:
-```bash
-repo_root=$(git rev-parse --show-toplevel)
-source <(${repo_root}/quickstart-mongodb-atlas/scripts/export-mongocli-config.py)
-cd ${repo_root}/cfn-resources/teams
-./test/teams.create-sample-cfn-request.sh {TEAM_NAME},{ ORGANIZATION_USER_EMAIL} > test.request.json 
-echo "Sample request:"
-cat test.request.json
-cfn invoke CREATE test.request.json 
-cfn invoke DELETE test.request.json 
-```
-
-Both CREATE & DELETE tests must pass.
+See the [resource docs](./docs/README.md).
 
 ## Installation
+
+```
 TAGS=logging make
 cfn submit --verbose --set-default
+```
 
 ## CloudFormation Examples
 
-Please see the [CFN Template](/examples/teams/teams.json) for example resource
+See the examples [CFN Template](/examples/teams/teams.json) for example resource.
 
-## Integration Testing w/ AWS
+## Integration Testing with AWS
 
 The [/quickstart-mongodb-atlas/scripts/launch-quickstart.sh](https://github.com/mongodb/mongodbatlas-cloudformation-resources/blob/master/quickstart-mongodb-atlas/scripts/launch-quickstart.sh) script
 can be used to safely inject your MongoDB Cloud ApiKey environment variables into an example
@@ -60,4 +42,4 @@ source <(${repo_root}/quickstart-mongodb-atlas/scripts/export-mongocli-config.py
 ${repo_root}/quickstart-mongodb-atlas/scripts/launch-x-quickstart.sh ${repo_root}/cfn-resources/teams/test/teams.sample-template.yaml SampleAccessList1 ParameterKey=Name,ParameterValue=<YOUR_TEAM_NAME>  ParameterKey=Usernames,ParameterValue=<email id of one user assigned to your organization>
 ```
 
-For more information see: MongoDB Atlas API [Teams Endpoint](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Teams) Documentation.
+For more information see the MongoDB Atlas API documentation for [Teams](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Teams).

--- a/cfn-resources/teams/README.md
+++ b/cfn-resources/teams/README.md
@@ -1,45 +1,18 @@
 # MongoDB::Atlas::Teams
 
 ## Description
-Returns, adds, edits, or removes teams to Atlas Organization and Atlas Project (if specified).
+Resource for managing [Teams](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Teams)
+in Atlas Organization and Atlas Project.
+
+## Requirements
+
+Set up an AWS profile to securely give CloudFormation access to your Atlas credentials.
+For instructions on setting up a profile, [see here](/README.md#mongodb-atlas-api-keys-credential-management).
 
 ## Attributes and Parameters
 
 See the [resource docs](./docs/README.md).
 
-## Installation
-
-```
-TAGS=logging make
-cfn submit --verbose --set-default
-```
-
 ## CloudFormation Examples
 
 See the examples [CFN Template](/examples/teams/teams.json) for example resource.
-
-## Integration Testing with AWS
-
-The [/quickstart-mongodb-atlas/scripts/launch-quickstart.sh](https://github.com/mongodb/mongodbatlas-cloudformation-resources/blob/master/quickstart-mongodb-atlas/scripts/launch-quickstart.sh) script
-can be used to safely inject your MongoDB Cloud ApiKey environment variables into an example
-CloudFormation stack template along with the other necessary parameters.
-
-You can use the teams.sample-template.yaml to create a stack using the resource.
-Similar to the local testing described above you can follow the logs for the deployed
-lambda function which handles the request for the Resource Type.
-
-In one shell session:
-```
-aws logs tail mongodb-atlas-teams-logs --follow
-```
-
-And then you can create the stack with a helper script it insert the apikeys for you:
-
-
-```bash
-repo_root=$(git rev-parse --show-toplevel)
-source <(${repo_root}/quickstart-mongodb-atlas/scripts/export-mongocli-config.py)
-${repo_root}/quickstart-mongodb-atlas/scripts/launch-x-quickstart.sh ${repo_root}/cfn-resources/teams/test/teams.sample-template.yaml SampleAccessList1 ParameterKey=Name,ParameterValue=<YOUR_TEAM_NAME>  ParameterKey=Usernames,ParameterValue=<email id of one user assigned to your organization>
-```
-
-For more information see the MongoDB Atlas API documentation for [Teams](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Teams).

--- a/cfn-resources/teams/test/README.md
+++ b/cfn-resources/teams/test/README.md
@@ -1,59 +1,33 @@
 ## MongoDB::Atlas::Teams
 
 ### Impact 
-The following components use this resource and are potentially impacted by any changes. They should also be validated to ensure the changes do not cause a regression.
- - Teams L1 CDK constructor
-
-
+The following components use this resource and are potentially impacted by any changes.
+They should also be validated to ensure the changes do not cause a regression.
+ 
+- Teams L1 CDK constructor
 
 ### Resources (and parameters for local tests) needed to manually QA:
 The Atlas organization must be manually provided.
-- Atlas Organization (ATLAS_ORG_ID)
+- Atlas Organization (`ATLAS_ORG_ID`)
 - Atlas Project (created as part of `cfn-testing-helper.sh`)
-
-
 
 ## Manual QA:
 
-### Prerequisite steps:
+### Prerequisites
 1. Create an Atlas Organization if you don’t already have one.
-2. Export environment variable ATLAS_ORG_ID with the value as your Organization Id. You can get this Id from your Atlas UI
-   by clicking on your organization and note the Organization Id from the URL (which should look like this https://cloud.mongodb.com/v2#/org/<ATLAS_ORG_ID>/projects)
-
+2. Export environment variable `ATLAS_ORG_ID` with the value as your Organization Id.
+   You can get this ID from your Atlas UI by clicking on your organization and note the Organization ID from the URL
+   which should look like this https://cloud.mongodb.com/v2#/org/<ATLAS_ORG_ID>/projects.
 
 ### Steps to test:
-1. Ensure prerequisites above for this resource and general [prerequisites](../../../TESTING.md.md#prerequisites) are complete.
-2. Follow [general steps](../../../TESTING.md.md#steps) to test a CFN resource.
-
+1. Ensure prerequisites above for this resource and general [prerequisites](/TESTING.md.md#prerequisites) are complete.
+2. Follow [general steps](/TESTING.md.md#steps) to test a CFN resource.
 
 ### Success criteria when testing the resource
 1. Atlas Team should show correctly configured in respective Organization's Access Manager (and in Project Access Manager, if applicable):
-
-![image](https://user-images.githubusercontent.com/122359335/227534552-a338f068-2e60-4179-91cd-7a634a2dc9b3.png)
-
+   ![image](https://user-images.githubusercontent.com/122359335/227534552-a338f068-2e60-4179-91cd-7a634a2dc9b3.png)
 2. General [CFN resource success criteria](../../../TESTING.md.md#success-criteria-when-testing-the-resource) should be satisfied.
 
 ## Important Links
 - [API Documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Teams)
 - [Resource Usage Documentation](https://www.mongodb.com/docs/atlas/access/manage-teams-in-orgs/)
-
-## Unit Testing Locally
-
-The local tests are integrated with the AWS `sam local` and `cfn invoke` tooling features:
-
-```
-sam local start-lambda --skip-pull-image
-```
-then in another shell:
-```bash
-repo_root=$(git rev-parse --show-toplevel)
-source <(${repo_root}/quickstart-mongodb-atlas/scripts/export-mongocli-config.py)
-cd ${repo_root}/cfn-resources/teams
-./test/teams.create-sample-cfn-request.sh {TEAM_NAME},{ ORGANIZATION_USER_EMAIL} > test.request.json 
-echo "Sample request:"
-cat test.request.json
-cfn invoke CREATE test.request.json 
-cfn invoke DELETE test.request.json 
-```
-
-Both CREATE and DELETE tests must pass.

--- a/cfn-resources/teams/test/README.md
+++ b/cfn-resources/teams/test/README.md
@@ -26,7 +26,7 @@ The Atlas organization must be manually provided.
 ### Success criteria when testing the resource
 1. Atlas Team should show correctly configured in respective Organization's Access Manager (and in Project Access Manager, if applicable):
    ![image](https://user-images.githubusercontent.com/122359335/227534552-a338f068-2e60-4179-91cd-7a634a2dc9b3.png)
-2. General [CFN resource success criteria](../../../TESTING.md.md#success-criteria-when-testing-the-resource) should be satisfied.
+2. General [CFN resource success criteria](/TESTING.md.md#success-criteria-when-testing-the-resource) should be satisfied.
 
 ## Important Links
 - [API Documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Teams)

--- a/cfn-resources/teams/test/README.md
+++ b/cfn-resources/teams/test/README.md
@@ -36,3 +36,24 @@ The Atlas organization must be manually provided.
 ## Important Links
 - [API Documentation](https://www.mongodb.com/docs/atlas/reference/api-resources-spec/#tag/Teams)
 - [Resource Usage Documentation](https://www.mongodb.com/docs/atlas/access/manage-teams-in-orgs/)
+
+## Unit Testing Locally
+
+The local tests are integrated with the AWS `sam local` and `cfn invoke` tooling features:
+
+```
+sam local start-lambda --skip-pull-image
+```
+then in another shell:
+```bash
+repo_root=$(git rev-parse --show-toplevel)
+source <(${repo_root}/quickstart-mongodb-atlas/scripts/export-mongocli-config.py)
+cd ${repo_root}/cfn-resources/teams
+./test/teams.create-sample-cfn-request.sh {TEAM_NAME},{ ORGANIZATION_USER_EMAIL} > test.request.json 
+echo "Sample request:"
+cat test.request.json
+cfn invoke CREATE test.request.json 
+cfn invoke DELETE test.request.json 
+```
+
+Both CREATE and DELETE tests must pass.


### PR DESCRIPTION
We're working to improve the overall documentation for CFN with Atlas. To that end, the docs team would like to first go through the READMEs for each resource like the one here and remove some duplicate and outdated information. Most of these changes we discussed with @andreaangiolillo.

We'd like to get the team's approval on this PR first. Then we can make the same changes for each resource, and reduce the review burden for engineers.