### PR TITLE
Return connectionId when creating new peering connection

### DIFF
--- a/cfn-resources/network-peering/cmd/resource/resource.go
+++ b/cfn-resources/network-peering/cmd/resource/resource.go
@@ -108,6 +108,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	_, _ = logger.Debugf("Create peerResponse:%+v", peerResponse)
 	currentModel.Id = &peerResponse.ID
+	currentModel.ConnectionId = &peerResponse.ConnectionID
 
 	return handler.ProgressEvent{
 		OperationStatus: handler.Success,


### PR DESCRIPTION
The connectionId should be output because it may be fed into a resource for accepting the connection.