### PR TITLE
added ProviderName to cluster

### DIFF
--- a/cfn-resources/cluster/cmd/resource/model.go
+++ b/cfn-resources/cluster/cmd/resource/model.go
@@ -92,6 +92,7 @@ type AdvancedRegionConfig struct {
 	AnalyticsAutoScaling *AdvancedAutoScaling `json:",omitempty"`
 	AutoScaling          *AdvancedAutoScaling `json:",omitempty"`
 	RegionName           *string              `json:",omitempty"`
+	ProviderName         *string              `json:",omitempty"`
 	AnalyticsSpecs       *Specs               `json:",omitempty"`
 	ElectableSpecs       *Specs               `json:",omitempty"`
 	Priority             *int                 `json:",omitempty"`

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -468,8 +468,14 @@ func expandRegionConfig(regionCfg AdvancedRegionConfig) *mongodbatlas.AdvancedRe
 	if regionCfg.RegionName != nil {
 		region = *regionCfg.RegionName
 	}
+
+	providerName := constants.AWS
+	if regionCfg.ProviderName != nil {
+		providerName = *regionCfg.ProviderName
+	}
+
 	advRegionConfig := &mongodbatlas.AdvancedRegionConfig{
-		ProviderName: constants.AWS,
+		ProviderName: providerName,
 		RegionName:   region,
 		Priority:     regionCfg.Priority,
 	}
@@ -477,7 +483,6 @@ func expandRegionConfig(regionCfg AdvancedRegionConfig) *mongodbatlas.AdvancedRe
 	if regionCfg.AutoScaling != nil {
 		advRegionConfig.AutoScaling = expandAutoScaling(regionCfg.AutoScaling)
 	}
-
 	if regionCfg.AnalyticsAutoScaling != nil {
 		advRegionConfig.AnalyticsAutoScaling = expandAutoScaling(regionCfg.AnalyticsAutoScaling)
 	}

--- a/cfn-resources/cluster/docs/advancedregionconfig.md
+++ b/cfn-resources/cluster/docs/advancedregionconfig.md
@@ -17,6 +17,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "<a href="#analyticsautoscaling" title="AnalyticsAutoScaling">AnalyticsAutoScaling</a>" : <i><a href="advancedautoscaling.md">advancedAutoScaling</a></i>,
     "<a href="#autoscaling" title="AutoScaling">AutoScaling</a>" : <i><a href="advancedautoscaling.md">advancedAutoScaling</a></i>,
     "<a href="#regionname" title="RegionName">RegionName</a>" : <i>String</i>,
+    "<a href="#providername" title="ProviderName">ProviderName</a>" : <i>String</i>,
     "<a href="#analyticsspecs" title="AnalyticsSpecs">AnalyticsSpecs</a>" : <i><a href="specs.md">specs</a></i>,
     "<a href="#electablespecs" title="ElectableSpecs">ElectableSpecs</a>" : <i><a href="specs.md">specs</a></i>,
     "<a href="#priority" title="Priority">Priority</a>" : <i>Integer</i>,
@@ -30,6 +31,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <a href="#analyticsautoscaling" title="AnalyticsAutoScaling">AnalyticsAutoScaling</a>: <i><a href="advancedautoscaling.md">advancedAutoScaling</a></i>
 <a href="#autoscaling" title="AutoScaling">AutoScaling</a>: <i><a href="advancedautoscaling.md">advancedAutoScaling</a></i>
 <a href="#regionname" title="RegionName">RegionName</a>: <i>String</i>
+<a href="#providername" title="ProviderName">ProviderName</a>: <i>String</i>
 <a href="#analyticsspecs" title="AnalyticsSpecs">AnalyticsSpecs</a>: <i><a href="specs.md">specs</a></i>
 <a href="#electablespecs" title="ElectableSpecs">ElectableSpecs</a>: <i><a href="specs.md">specs</a></i>
 <a href="#priority" title="Priority">Priority</a>: <i>Integer</i>
@@ -61,6 +63,16 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 _Required_: No
 
 _Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ProviderName
+
+_Required_: No
+
+_Type_: String
+
+_Allowed Values_: <code>AWS</code> | <code>GCP</code> | <code>AZURE</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/cfn-resources/cluster/mongodb-atlas-cluster.json
+++ b/cfn-resources/cluster/mongodb-atlas-cluster.json
@@ -51,6 +51,14 @@
                 "RegionName": {
                     "type": "string"
                 },
+                "ProviderName": {
+                    "type": "string",
+                    "enum": [
+                        "AWS",
+                        "GCP",
+                        "AZURE"
+                    ]
+                },
                 "AnalyticsSpecs": {
                         "$ref": "#/definitions/specs"
                 },

--- a/examples/cluster/cluster.json
+++ b/examples/cluster/cluster.json
@@ -83,7 +83,8 @@
                   "NodeCount": "3"
                 },
                 "Priority": "7",
-                "RegionName": "US_EAST_1"
+                "RegionName": "US_EAST_1",
+                "ProviderName": "AWS"
               }
             ]
           }

--- a/examples/cluster/project-cluster.json
+++ b/examples/cluster/project-cluster.json
@@ -104,7 +104,8 @@
                   "NodeCount": "3"
                 },
                 "Priority": "7",
-                "RegionName": "US_EAST_1"
+                "RegionName": "US_EAST_1",
+                "ProviderName": "AWS"
               }
             ]
           }


### PR DESCRIPTION
## Proposed changes

Users were requesting we open the cluster creation to another providers, Originally the "ProviderName" property was close ONLY to AWS, now we allowed the users to input GCP, and AZURE

Link to any related issue(s): [HELP-46355](https://jira.mongodb.org/browse/HELP-46355)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [x] cfn invoke for each of CRUDL/cfn test
- [x] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

