### PR TITLE
Feature/issue 560 network peering error

### DIFF
--- a/cfn-resources/network-peering/cmd/resource/resource.go
+++ b/cfn-resources/network-peering/cmd/resource/resource.go
@@ -27,7 +27,6 @@ import (
 	progressevents "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	"go.mongodb.org/atlas/mongodbatlas"
-	"log"
 )
 
 func setup() {
@@ -92,8 +91,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	if _, ok := req.CallbackContext["stateName"]; ok {
 		currentModel.Id = aws.String(req.CallbackContext["id"].(string))
-		log.Printf("se asigno el ID = ")
-		log.Print(currentModel.Id)
 		return validateCreationProcess(client, currentModel), nil
 	}
 
@@ -113,7 +110,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		ProviderName:        constants.AWS,
 	}
 
-	_, _ = logger.Debugf("peerRequest:%+v", peerRequest)
 	peerResponse, resp, err := client.Peers.Create(context.Background(), projectID, &peerRequest)
 	if err != nil {
 		_, _ = logger.Warnf("error creating network peering: %s", err)
@@ -121,7 +117,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 			resp.Response), nil
 	}
 
-	_, _ = logger.Debugf("Create peerResponse:%+v", peerResponse)
+	currentModel.Id = &peerResponse.ID
 
 	return progressevents.GetInProgressProgressEvent("Creating",
 		map[string]interface{}{

--- a/cfn-resources/network-peering/cmd/resource/resource.go
+++ b/cfn-resources/network-peering/cmd/resource/resource.go
@@ -17,6 +17,7 @@ package resource
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -35,10 +36,10 @@ func setup() {
 
 const (
 	StatusPendingAcceptance string = "PENDING_ACCEPTANCE"
-	StatusFailed                   = "FAILED"
-	StatusAvailable                = "AVAILABLE"
-	StatusDeleted                  = "DELETED"
-	StatusInitiating               = "INITIATING"
+	StatusFailed            string = "FAILED"
+	StatusAvailable         string = "AVAILABLE"
+	StatusDeleted           string = "DELETED"
+	StatusInitiating        string = "INITIATING"
 )
 
 // Helper to check container id or create one for the AWS region for
@@ -360,20 +361,21 @@ func validateCreationProcess(client *mongodbatlas.Client, currentModel *Model) h
 	return progressevents.GetInProgressProgressEvent("Creating",
 		map[string]interface{}{
 			"stateName": state,
+			"id":        &currentModel.Id,
 		},
 		currentModel,
 		5,
 	)
 }
 
-func getStatus(client *mongodbatlas.Client, projectID, peerID string) (string, string, error) {
+func getStatus(client *mongodbatlas.Client, projectID, peerID string) (statusName string, errorStatusName string, err error) {
 	peerResponse, resp, err := client.Peers.Get(context.Background(), projectID, peerID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
 			return StatusDeleted, "", nil
-		} else {
-			return "", "", err
 		}
+
+		return "", "", err
 	}
 
 	return peerResponse.StatusName, peerResponse.ErrorStateName, nil

--- a/cfn-resources/network-peering/cmd/resource/resource.go
+++ b/cfn-resources/network-peering/cmd/resource/resource.go
@@ -17,7 +17,6 @@ package resource
 import (
 	"context"
 	"fmt"
-
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -28,11 +27,20 @@ import (
 	progressevents "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	"go.mongodb.org/atlas/mongodbatlas"
+	"log"
 )
 
 func setup() {
 	util.SetupLogger("mongodb-atlas-network-peering")
 }
+
+const (
+	StatusPendingAcceptance string = "PENDING_ACCEPTANCE"
+	StatusFailed                   = "FAILED"
+	StatusAvailable                = "AVAILABLE"
+	StatusDeleted                  = "DELETED"
+	StatusInitiating               = "INITIATING"
+)
 
 // Helper to check container id or create one for the AWS region for
 // the given project. This is patterned off the mongocli logic:
@@ -82,6 +90,13 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *peErr, nil
 	}
 
+	if _, ok := req.CallbackContext["stateName"]; ok {
+		currentModel.Id = aws.String(req.CallbackContext["id"].(string))
+		log.Printf("se asigno el ID = ")
+		log.Print(currentModel.Id)
+		return validateCreationProcess(client, currentModel), nil
+	}
+
 	projectID := *currentModel.ProjectId
 	awsAccountID := currentModel.AwsAccountId
 	if awsAccountID == nil || *awsAccountID == "" {
@@ -107,13 +122,15 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	_, _ = logger.Debugf("Create peerResponse:%+v", peerResponse)
-	currentModel.Id = &peerResponse.ID
 
-	return handler.ProgressEvent{
-		OperationStatus: handler.Success,
-		Message:         "Create complete",
-		ResourceModel:   currentModel,
-	}, nil
+	return progressevents.GetInProgressProgressEvent("Creating",
+		map[string]interface{}{
+			"stateName": StatusInitiating,
+			"id":        &peerResponse.ID,
+		},
+		currentModel,
+		5,
+	), nil
 }
 
 // Read handles the Read event from the Cloudformation service.
@@ -239,7 +256,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	if _, ok := req.CallbackContext["stateName"]; ok {
-		return validateProgress(client, currentModel, "DELETED")
+		return validateDeletionProcess(client, currentModel), nil
 	}
 
 	projectID := *currentModel.ProjectId
@@ -250,15 +267,13 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 			resp.Response), nil
 	}
 
-	return handler.ProgressEvent{
-		OperationStatus:      handler.InProgress,
-		Message:              "Delete in-progress",
-		ResourceModel:        currentModel,
-		CallbackDelaySeconds: 10,
-		CallbackContext: map[string]interface{}{
-			"stateName": "DELETING",
+	return progressevents.GetInProgressProgressEvent("Deleting",
+		map[string]interface{}{
+			"stateName": StatusDeleted,
 		},
-	}, nil
+		currentModel,
+		5,
+	), nil
 }
 
 // List handles the List event from the Cloudformation service.
@@ -306,45 +321,64 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}, nil
 }
 
-func validateProgress(client *mongodbatlas.Client, currentModel *Model, targetState string) (handler.ProgressEvent, error) {
-	isReady, state, err := networkPeeringIsReady(client, *currentModel.ProjectId, *currentModel.Id, targetState)
+func validateDeletionProcess(client *mongodbatlas.Client, currentModel *Model) handler.ProgressEvent {
+	state, _, err := getStatus(client, *currentModel.ProjectId, *currentModel.Id)
 	if err != nil {
+		return progressevents.GetFailedEventByCode(err.Error(), cloudformation.HandlerErrorCodeInvalidRequest)
+	}
+
+	if state == StatusDeleted {
 		return handler.ProgressEvent{
-			OperationStatus:  handler.Failed,
-			Message:          err.Error(),
-			HandlerErrorCode: cloudformation.HandlerErrorCodeInvalidRequest}, nil
-	}
-
-	if !isReady {
-		p := handler.NewProgressEvent()
-		p.ResourceModel = currentModel
-		p.OperationStatus = handler.InProgress
-		p.CallbackDelaySeconds = 15
-		p.Message = "Pending"
-		p.CallbackContext = map[string]interface{}{
-			"stateName": state,
+			OperationStatus: handler.Success,
+			Message:         "Complete",
 		}
-		return p, nil
 	}
 
-	p := handler.NewProgressEvent()
-	p.OperationStatus = handler.Success
-	p.Message = "Complete"
-	if state == "DELETED" {
-		_, _ = logger.Debugf("Do not set ResourceModel property for DELETED resources")
-	} else {
-		_, _ = logger.Debugf("validateProgress isReady was true but state not DELETED?")
-		p.ResourceModel = currentModel
-	}
-	return p, nil
+	return progressevents.GetInProgressProgressEvent("Deleting",
+		map[string]interface{}{
+			"stateName": state,
+		},
+		currentModel,
+		5,
+	)
 }
 
-func networkPeeringIsReady(client *mongodbatlas.Client, projectID, peerID, targetState string) (isReady bool, statusName string, err error) {
+func validateCreationProcess(client *mongodbatlas.Client, currentModel *Model) handler.ProgressEvent {
+	state, errorMessage, err := getStatus(client, *currentModel.ProjectId, *currentModel.Id)
+	if err != nil {
+		return progressevents.GetFailedEventByCode(err.Error(), cloudformation.HandlerErrorCodeInvalidRequest)
+	}
+
+	if state == StatusPendingAcceptance || state == StatusAvailable {
+		return handler.ProgressEvent{
+			OperationStatus: handler.Success,
+			Message:         "Complete",
+			ResourceModel:   currentModel,
+		}
+	}
+
+	if state == StatusFailed {
+		return progressevents.GetFailedEventByCode(errorMessage, cloudformation.HandlerErrorCodeInternalFailure)
+	}
+
+	return progressevents.GetInProgressProgressEvent("Creating",
+		map[string]interface{}{
+			"stateName": state,
+		},
+		currentModel,
+		5,
+	)
+}
+
+func getStatus(client *mongodbatlas.Client, projectID, peerID string) (string, string, error) {
 	peerResponse, resp, err := client.Peers.Get(context.Background(), projectID, peerID)
 	if err != nil {
 		if resp != nil && resp.StatusCode == 404 {
-			return true, "DELETED", nil
+			return StatusDeleted, "", nil
+		} else {
+			return "", "", err
 		}
 	}
-	return peerResponse.StatusName == targetState, peerResponse.StatusName, nil
+
+	return peerResponse.StatusName, peerResponse.ErrorStateName, nil
 }

--- a/examples/network-peering/peering.json
+++ b/examples/network-peering/peering.json
@@ -80,12 +80,12 @@
         "Ref": "NetworkPeering"
       }
     },
-    "ConnId": {
+    "ConnectionId": {
       "Description": "Peering Status",
       "Value": {
         "Fn::GetAtt": [
           "NetworkPeering",
-          "StatusName"
+          "ConnectionId"
         ]
       }
     }


### PR DESCRIPTION
## Proposed changes

Previously, the cloud formation CREATE workflow operated synchronously, even though the Atlas NetworkPeering was asyncroinous, (in other words Cloud Formation was returning success but the resource was not 100% available yet) which caused issues for users trying to access properties such as the ConnectionID. This was due to the fact that the ConnectionID was assigned only after the resource creation process was completed.

To address this problem, the cloud formation resource CREATE flow will wait until the network peering reaches the "PENDING_ACCEPTANCE" or "AVAILABLE" state before returning a success status. If the peering fails with a "FAILED" status, the cloud formation resource, returns a fail status. This will ensure that all the required properties are available once the resource returns a success status.

_Jira ticket:_ CLOUDP-#

This solution was in response of an issue reported in this pull request https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/560

Testing:

cfn test:
![image](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/69170650/5bf91439-1207-47c7-9b8d-f40aa8ac5541)

cfn submit:
using the examples json file i was able to create a network peering resource and output the ConnectionId 
<img width="1112" alt="image" src="https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/69170650/750303ad-3565-49b1-a194-c2766c334098">


Link to any related issue(s): 


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [x] This change requires a documentation update

## Manual QA performed:

- [x] cfn invoke for each of CRUDL/cfn test
- [x] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [x] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

