### PR TITLE
added support for M0

### DIFF
--- a/cfn-resources/cluster/cmd/resource/model.go
+++ b/cfn-resources/cluster/cmd/resource/model.go
@@ -93,6 +93,7 @@ type AdvancedRegionConfig struct {
 	AnalyticsAutoScaling *AdvancedAutoScaling `json:",omitempty"`
 	AutoScaling          *AdvancedAutoScaling `json:",omitempty"`
 	RegionName           *string              `json:",omitempty"`
+	BackingProviderName  *string              `json:",omitempty"`
 	ProviderName         *string              `json:",omitempty"`
 	AnalyticsSpecs       *Specs               `json:",omitempty"`
 	ElectableSpecs       *Specs               `json:",omitempty"`

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -389,6 +389,9 @@ func clusterCallback(client *mongodbatlas.Client, currentModel *Model, projectID
 }
 
 func (m *Model) HasAdvanceSettings() bool {
+	/*This logic is because of a bug un Cloud Formation, when we return in_progress in the CREATE
+	,the second time the CREATE gets executed
+	it returns the AdvancedSettings is not nil but its fields are nil*/
 	return m.AdvancedSettings != nil && (m.AdvancedSettings.DefaultReadConcern != nil ||
 		m.AdvancedSettings.DefaultWriteConcern != nil ||
 		m.AdvancedSettings.FailIndexKeyTooLong != nil ||

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -402,7 +402,6 @@ func (m *Model) HasAdvanceSettings() bool {
 		m.AdvancedSettings.SampleSizeBIConnector != nil ||
 		m.AdvancedSettings.SampleRefreshIntervalBIConnector != nil ||
 		m.AdvancedSettings.OplogMinRetentionHours != nil)
-
 }
 
 func containsLabelOrKey(list []Labels, item Labels) bool {

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -88,7 +88,7 @@ func Create(req handler.Request, _ *Model, currentModel *Model) (handler.Progres
 		return *peErr, nil
 	}
 
-	_, _ = log.Debugf("Cluster create projectId: %s, clusterName: %s ", *currentModel.ProjectId, *currentModel.Name)
+	_, _ = log.Debugf("Cluster create projectId: %s, clusterName: %s", *currentModel.ProjectId, *currentModel.Name)
 
 	// Callback
 	if _, idExists := req.CallbackContext[constants.StateName]; idExists {
@@ -389,9 +389,6 @@ func clusterCallback(client *mongodbatlas.Client, currentModel *Model, projectID
 }
 
 func (m *Model) HasAdvanceSettings() bool {
-	/*TODO: this logic is because of a bug un Cloud Formation, when we return in_progress in the CREATE
-	,the second time the CREATE gets executed
-	it returns the AdvancedSettings is not nil but its fields are nil*/
 	return m.AdvancedSettings != nil && (m.AdvancedSettings.DefaultReadConcern != nil ||
 		m.AdvancedSettings.DefaultWriteConcern != nil ||
 		m.AdvancedSettings.FailIndexKeyTooLong != nil ||

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	LabelError      = "you should not set `Infrastructure Tool` label, it is used for internal purposes"
-	CallBackSeconds = 60
+	CallBackSeconds = 40
 )
 
 var defaultLabel = Labels{Key: aws.String("Infrastructure Tool"), Value: aws.String("MongoDB Atlas CloudFormation Provider")}
@@ -96,10 +96,6 @@ func Create(req handler.Request, _ *Model, currentModel *Model) (handler.Progres
 	}
 
 	var err error
-	var none = "NONE"
-	if currentModel.EncryptionAtRestProvider == nil {
-		currentModel.EncryptionAtRestProvider = &none
-	}
 
 	currentModel.validateDefaultLabel()
 
@@ -369,7 +365,15 @@ func clusterCallback(client *mongodbatlas.Client, currentModel *Model, projectID
 	if err != nil {
 		return progressEvent, nil
 	}
+
 	if progressEvent.Message == constants.Complete {
+		if !currentModel.HasAdvanceSettings() {
+			return handler.ProgressEvent{
+				OperationStatus: handler.Success,
+				Message:         "Create Success",
+				ResourceModel:   currentModel}, nil
+		}
+
 		_, _ = log.Debugf("Cluster Creation completed:%s", *currentModel.Name)
 
 		cluster, res, err := client.AdvancedClusters.Get(context.Background(), projectID, *currentModel.Name)
@@ -377,10 +381,28 @@ func clusterCallback(client *mongodbatlas.Client, currentModel *Model, projectID
 			return progress_events.GetFailedEventByResponse(fmt.Sprintf("Error creating resource : %s", err.Error()),
 				res.Response), nil
 		}
+
 		_, _ = log.Debugf("Updating cluster settings:%s", *currentModel.Name)
 		return updateClusterSettings(currentModel, client, projectID, cluster, &progressEvent)
 	}
 	return progressEvent, nil
+}
+
+func (m *Model) HasAdvanceSettings() bool {
+	/*TODO: this logic is because of a bug un Cloud Formation, when we return in_progress in the CREATE
+	,the second time the CREATE gets executed
+	it returns the AdvancedSettings is not nil but its fields are nil*/
+	return m.AdvancedSettings != nil && (m.AdvancedSettings.DefaultReadConcern != nil ||
+		m.AdvancedSettings.DefaultWriteConcern != nil ||
+		m.AdvancedSettings.FailIndexKeyTooLong != nil ||
+		m.AdvancedSettings.JavascriptEnabled != nil ||
+		m.AdvancedSettings.MinimumEnabledTLSProtocol != nil ||
+		m.AdvancedSettings.NoTableScan != nil ||
+		m.AdvancedSettings.OplogSizeMB != nil ||
+		m.AdvancedSettings.SampleSizeBIConnector != nil ||
+		m.AdvancedSettings.SampleRefreshIntervalBIConnector != nil ||
+		m.AdvancedSettings.OplogMinRetentionHours != nil)
+
 }
 
 func containsLabelOrKey(list []Labels, item Labels) bool {
@@ -495,6 +517,9 @@ func expandRegionConfig(regionCfg AdvancedRegionConfig) *mongodbatlas.AdvancedRe
 	}
 	if regionCfg.ReadOnlySpecs != nil {
 		advRegionConfig.ReadOnlySpecs = expandRegionConfigSpec(regionCfg.ReadOnlySpecs)
+	}
+	if regionCfg.BackingProviderName != nil {
+		advRegionConfig.BackingProviderName = *regionCfg.BackingProviderName
 	}
 	return advRegionConfig
 }
@@ -1001,9 +1026,8 @@ func validateProgress(client *mongodbatlas.Client, currentModel *Model, currentS
 func setClusterRequest(currentModel *Model, err error) (*mongodbatlas.AdvancedCluster, handler.ProgressEvent, error) {
 	// Atlas client
 	clusterRequest := &mongodbatlas.AdvancedCluster{
-		Name:                     *currentModel.Name,
-		EncryptionAtRestProvider: *currentModel.EncryptionAtRestProvider,
-		ReplicationSpecs:         expandReplicationSpecs(currentModel.ReplicationSpecs),
+		Name:             *currentModel.Name,
+		ReplicationSpecs: expandReplicationSpecs(currentModel.ReplicationSpecs),
 	}
 
 	if currentModel.EncryptionAtRestProvider != nil {

--- a/cfn-resources/cluster/mongodb-atlas-cluster.json
+++ b/cfn-resources/cluster/mongodb-atlas-cluster.json
@@ -51,12 +51,16 @@
                 "RegionName": {
                     "type": "string"
                 },
+                "BackingProviderName" : {
+                    "type": "string"
+                },
                 "ProviderName": {
                     "type": "string",
                     "enum": [
                         "AWS",
                         "GCP",
-                        "AZURE"
+                        "AZURE",
+                        "TENANT"
                     ]
                 },
                 "AnalyticsSpecs": {

--- a/examples/cluster/free-tier-M0-cluster.json
+++ b/examples/cluster/free-tier-M0-cluster.json
@@ -1,0 +1,90 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "This template creates a cluster on the MongoDB Atlas API, this will be billed to your Atlas account.",
+  "Parameters": {
+    "ProjectId": {
+      "Type": "String",
+      "Description": "Unique 24-hexadecimal digit string that identifies your project"
+    },
+    "ClusterName": {
+      "Type": "String",
+      "Description": "Name to use for your Atlas Cluster",
+      "Default" : "Cluster0"
+    },
+    "Profile": {
+      "Type": "String",
+      "Description": "Secret Manager Profile that contains the Atlas Programmatic keys",
+      "Default": "default"
+    }
+  },
+  "Resources": {
+    "AtlasCluster": {
+      "Type": "MongoDB::Atlas::Cluster",
+      "Properties": {
+        "ProjectId": {
+          "Ref": "ProjectId"
+        },
+        "Name": {
+          "Ref": "ClusterName"
+        },
+        "Profile": {
+          "Ref": "Profile"
+        },
+        "ClusterType": "REPLICASET",
+        "ReplicationSpecs": [
+          {
+            "NumShards": "1",
+            "AdvancedRegionConfigs": [
+              {
+                "AnalyticsSpecs": {
+                  "EbsVolumeType": "STANDARD",
+                  "InstanceSize": "M0",
+                  "NodeCount": "1"
+                },
+                "ElectableSpecs": {
+                  "EbsVolumeType": "STANDARD",
+                  "InstanceSize": "M0",
+                  "NodeCount": "3"
+                },
+                "Priority": "7",
+                "RegionName": "US_EAST_1",
+                "ProviderName": "TENANT",
+                "BackingProviderName": "AWS"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+    "MongoDBAtlasConnectionStrings": {
+      "Description": "Cluster connection strings",
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${AWS::StackName}-ConnectionStrings"
+        }
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "AtlasCluster",
+          "ConnectionStrings.Standard"
+        ]
+      }
+    },
+    "MongoDBAtlasClusterID": {
+      "Description": "Cluster Id",
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${AWS::StackName}-ID"
+        }
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "AtlasCluster",
+          "Id"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed changes

added support for for M0:

- Added new Provider Name "Tenant"
- Added new proerty required for Tenant, "BackingProviderName"
- Added validation to avoid calling the ProcessArgs when AdvancedSettings is not present
- Added example file


_Jira ticket:_ [INTMDB-905](https://jira.mongodb.org/browse/INTMDB-905)


## Testing:

cfn testing: 
![image](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/69170650/8054f907-ad65-4071-9b21-2aa73b0004e3)

![image](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/69170650/adea16da-6063-4861-852c-6e3d5ad8864a)

![image](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/69170650/5bfd5d22-82cb-496c-8665-602443bcf5e3)

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [x] cfn invoke for each of CRUDL/cfn test
- [x] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [x] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

