### PR TITLE
fix: ldap verify publishing script

### DIFF
--- a/cfn-resources/ldap-verify/test/cfn-test-delete-inputs.sh
+++ b/cfn-resources/ldap-verify/test/cfn-test-delete-inputs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# cfn-test-delete-inputs.sh
+#
+# This tool deletes the mongodb resources used for `cfn test` as inputs.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function usage {
+	echo "usage:$0 "
+}
+
+
+projectId=$(jq -r '.ProjectId' ./inputs/inputs_1_create.json)
+
+cluster_names=$(atlas clusters list --projectId "$projectId" --output=json | jq -r '.results[].name')
+
+# Get the first cluster name from the list
+first_cluster_name=$(echo "$cluster_names" | head -n 1)
+
+if [ -n "$first_cluster_name" ]; then
+    echo "Deleting cluster: $first_cluster_name"
+
+    # Delete Cluster
+    if atlas clusters delete "$first_cluster_name" --projectId "$projectId" --force; then
+        echo "$first_cluster_name cluster deletion OK"
+    else
+        (echo "Failed cleaning cluster:$first_cluster_name" && exit 1)
+    fi
+
+    status="DELETING"
+    echo "Waiting for cluster to get deleted"
+    while [[ "${status}" == "DELETING" ]]; do
+        sleep 30
+        if atlas clusters describe "$first_cluster_name" --projectId "$projectId"; then
+            status=$(atlas clusters describe "$first_cluster_name" --projectId "$projectId" --output=json | jq -r '.stateName')
+        else
+            status="DELETED"
+        fi
+        echo "status: ${status}"
+    done
+else
+    echo "No clusters found in the project."
+fi
+
+#delete project
+if atlas projects delete "$projectId" --force; then
+	echo "$projectId project deletion OK"
+else
+	(echo "Failed cleaning project:$projectId" && exit 1)
+fi


### PR DESCRIPTION
## Proposed changes

the ldap-verify does not contained a delete test script, so the resources remained after the resource had finished testing.

Link to any related issue(s): 


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [x] cfn invoke for each of CRUDL/cfn test
- [x] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [x] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

