### PR TITLE
refactor: Migrates Project resource to new Atlas SDK

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -21,7 +21,7 @@ This file contains the steps to follow to test any changes to the CFN resources.
 ```
 
    - Open a new terminal session
-   - Generate the cfn test inputs file and required Atlas resources. Each resource may require specific environment variables to be defined, you will find this under `cfn-resources/[resource-folder]/test/cfn-test-create-inputs.sh`
+   - Generate the cfn test inputs file and required Atlas resources. Each resource may require specific environment variables to be defined, you will find this under `cfn-resources/[resource-folder]/test/cfn-test-create-inputs.sh`. Generated input files also assume you have a `default` profile defined which will be used.
 ```bash
    ./../../cfn-testing-helper.sh <resource-folder>
 ```

--- a/cfn-resources/organization/cmd/resource/resource.go
+++ b/cfn-resources/organization/cmd/resource/resource.go
@@ -352,7 +352,7 @@ func handleError(response *http.Response, method constants.CfnFunctions, err err
 
 func setAPIkeyInputs(currentModel *Model) (apiKeyInput *atlasSDK.CreateAtlasOrganizationApiKey) {
 	apiKeyInput = &atlasSDK.CreateAtlasOrganizationApiKey{
-		Desc:  *currentModel.APIKey.Description,
+		Desc:  util.SafeString(currentModel.APIKey.Description),
 		Roles: currentModel.APIKey.Roles,
 	}
 	return apiKeyInput

--- a/cfn-resources/project/cmd/resource/resource.go
+++ b/cfn-resources/project/cmd/resource/resource.go
@@ -381,7 +381,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 // Read project
 func getProject(client *admin.APIClient, currentModel *Model) (event handler.ProgressEvent, model *Model, err error) {
 	var project *admin.Group
-	if currentModel.Name != nil && len(*currentModel.Name) > 0 {
+	if util.IsStringPresent(currentModel.Name) {
 		event, project, err = getProjectByName(currentModel.Name, client)
 		if err != nil {
 			return event, nil, err
@@ -474,7 +474,7 @@ func readProjectSettings(atlasV2 *admin.APIClient, id string, currentModel *Mode
 	// Set teams
 	var teams []ProjectTeam
 	for _, team := range teamsAssigned.Results {
-		if team.TeamId != nil && len(*team.TeamId) > 0 {
+		if util.IsStringPresent(team.TeamId) {
 			teams = append(teams, ProjectTeam{TeamId: team.TeamId, RoleNames: team.RoleNames})
 		}
 	}
@@ -488,10 +488,10 @@ func readProjectSettings(atlasV2 *admin.APIClient, id string, currentModel *Mode
 func getChangeInTeams(currentTeams []ProjectTeam, oTeams []admin.TeamRole) (newTeams []admin.TeamRole,
 	changedTeams []admin.TeamRole, removeTeams []admin.TeamRole) {
 	for _, nTeam := range currentTeams {
-		if nTeam.TeamId != nil && len(*nTeam.TeamId) > 0 {
+		if util.IsStringPresent(nTeam.TeamId) {
 			matched := false
 			for _, oTeam := range oTeams {
-				if nTeam.TeamId != nil && oTeam.TeamId != nil && *nTeam.TeamId == *oTeam.TeamId {
+				if util.AreStringPtrEqual(nTeam.TeamId, oTeam.TeamId) {
 					changedTeams = append(changedTeams, admin.TeamRole{TeamId: nTeam.TeamId, RoleNames: nTeam.RoleNames})
 					matched = true
 					break
@@ -505,10 +505,10 @@ func getChangeInTeams(currentTeams []ProjectTeam, oTeams []admin.TeamRole) (newT
 	}
 
 	for _, oTeam := range oTeams {
-		if oTeam.TeamId != nil && len(*oTeam.TeamId) > 0 {
+		if util.IsStringPresent(oTeam.TeamId) {
 			matched := false
 			for _, nTeam := range currentTeams {
-				if nTeam.TeamId != nil && oTeam.TeamId != nil && *nTeam.TeamId == *oTeam.TeamId {
+				if util.AreStringPtrEqual(nTeam.TeamId, oTeam.TeamId) {
 					matched = true
 					break
 				}
@@ -524,10 +524,10 @@ func getChangeInTeams(currentTeams []ProjectTeam, oTeams []admin.TeamRole) (newT
 // Get difference in ApiKeys
 func getChangeInAPIKeys(groupID string, currentKeys []ProjectApiKey, oKeys []admin.ApiKeyUserDetails) (newKeys, changedKeys, removeKeys []UpdateAPIKey) {
 	for _, nKey := range currentKeys {
-		if nKey.Key != nil && len(*nKey.Key) > 0 {
+		if util.IsStringPresent(nKey.Key) {
 			matched := false
 			for _, oKey := range oKeys {
-				if nKey.Key != nil && oKey.Id != nil && *nKey.Key == *oKey.Id {
+				if util.AreStringPtrEqual(nKey.Key, oKey.Id) {
 					changedKeys = append(changedKeys, UpdateAPIKey{Key: *nKey.Key, UpdatePayload: &admin.UpdateAtlasProjectApiKey{Roles: nKey.RoleNames}})
 					matched = true
 					break
@@ -541,10 +541,10 @@ func getChangeInAPIKeys(groupID string, currentKeys []ProjectApiKey, oKeys []adm
 	}
 
 	for _, oKey := range oKeys {
-		if oKey.Id != nil && len(*oKey.Id) > 0 {
+		if util.IsStringPresent(oKey.Id) {
 			matched := false
 			for _, nKey := range currentKeys {
-				if nKey.Key != nil && *nKey.Key == *oKey.Id {
+				if util.AreStringPtrEqual(nKey.Key, oKey.Id) {
 					matched = true
 					break
 				}
@@ -552,7 +552,7 @@ func getChangeInAPIKeys(groupID string, currentKeys []ProjectApiKey, oKeys []adm
 			if !matched {
 				for _, role := range oKey.Roles {
 					// Consider only current ProjectRoles
-					if role.GroupId != nil && *role.GroupId == groupID {
+					if util.AreStringPtrEqual(role.GroupId, &groupID) {
 						removeKeys = append(removeKeys, UpdateAPIKey{Key: *oKey.Id})
 					}
 				}
@@ -565,7 +565,7 @@ func getChangeInAPIKeys(groupID string, currentKeys []ProjectApiKey, oKeys []adm
 func readTeams(teams []ProjectTeam) []admin.TeamRole {
 	var newTeams []admin.TeamRole
 	for _, t := range teams {
-		if t.TeamId != nil && len(*t.TeamId) > 0 {
+		if util.IsStringPresent(t.TeamId) {
 			newTeams = append(newTeams, admin.TeamRole{TeamId: t.TeamId, RoleNames: t.RoleNames})
 		}
 	}

--- a/cfn-resources/project/cmd/resource/resource.go
+++ b/cfn-resources/project/cmd/resource/resource.go
@@ -28,15 +28,15 @@ import (
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
 	progressevents "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20230201008/admin"
 )
 
 var CreateRequiredFields = []string{constants.OrgID, constants.Name}
 var UpdateRequiredFields = []string{constants.ID}
 
 type UpdateAPIKey struct {
-	Key     string
-	APIKeys *mongodbatlas.AssignAPIKey
+	Key           string
+	UpdatePayload *admin.UpdateAtlasProjectApiKey
 }
 
 func setup() {
@@ -61,63 +61,72 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
 		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
-	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
+	client, pe := util.NewAtlasClient(&req, currentModel.Profile)
+	atlasV2 := client.AtlasV2
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
 		return *pe, nil
 	}
 
-	var projectOwnerID string
-	if currentModel.ProjectOwnerId != nil {
-		projectOwnerID = *currentModel.ProjectOwnerId
-	}
-	projectInput := &mongodbatlas.Project{
+	projectInput := &admin.Group{
 		Name:                      *currentModel.Name,
-		OrgID:                     *currentModel.OrgId,
+		OrgId:                     *currentModel.OrgId,
 		WithDefaultAlertsSettings: currentModel.WithDefaultAlertsSettings,
 	}
 	if currentModel.RegionUsageRestrictions != nil {
-		projectInput.RegionUsageRestrictions = *currentModel.RegionUsageRestrictions
+		projectInput.RegionUsageRestrictions = currentModel.RegionUsageRestrictions
 	}
 
-	project, res, err := client.Projects.Create(context.Background(), projectInput, &mongodbatlas.CreateProjectOptions{ProjectOwnerID: projectOwnerID})
+	createProjectReq := admin.CreateProjectApiParams{
+		Group: projectInput,
+	}
+	if currentModel.ProjectOwnerId != nil {
+		createProjectReq.ProjectOwnerId = currentModel.ProjectOwnerId
+	}
+	project, res, err := atlasV2.ProjectsApi.CreateProjectWithParams(context.Background(), &createProjectReq).Execute()
+
 	if err != nil {
 		_, _ = logger.Debugf("Create - error: %+v", err)
 		return progressevents.GetFailedEventByResponse(fmt.Sprintf("Failed to Create Project : %s", err.Error()),
-			res.Response), nil
+			res), nil
 	}
 
 	// Add ApiKeys
 	if len(currentModel.ProjectApiKeys) > 0 {
 		for _, key := range currentModel.ProjectApiKeys {
-			_, err = client.ProjectAPIKeys.Assign(context.Background(), project.ID, *key.Key, &mongodbatlas.AssignAPIKey{Roles: key.RoleNames})
+			_, res, err := atlasV2.ProgrammaticAPIKeysApi.UpdateApiKeyRoles(context.Background(), *project.Id, *key.Key, &admin.UpdateAtlasProjectApiKey{
+				Roles: key.RoleNames,
+			}).Execute()
 			if err != nil {
 				_, _ = logger.Warnf("Assign Key Error: %s", err)
 				return progressevents.GetFailedEventByResponse(fmt.Sprintf("Error while Assigning Key to project : %s", err.Error()),
-					res.Response), nil
+					res), nil
 			}
 		}
 	}
 
 	// Add Teams
 	if len(currentModel.ProjectTeams) > 0 {
-		_, _, err = client.Projects.AddTeamsToProject(context.Background(), project.ID, readTeams(currentModel.ProjectTeams))
+		teams := readTeams(currentModel.ProjectTeams)
+		_, _, err := atlasV2.TeamsApi.AddAllTeamsToProject(context.Background(), *project.Id, &teams).Execute()
 		if err != nil {
 			_, _ = logger.Warnf("AddTeamsToProject Error: %s", err)
 			return progressevents.GetFailedEventByResponse(fmt.Sprintf("Error while adding teams to project : %s", err.Error()),
-				res.Response), nil
+				res), nil
 		}
 	}
 
-	currentModel.Id = &project.ID
-	currentModel.Created = &project.Created
-	currentModel.ClusterCount = &project.ClusterCount
+	formattedCreated := util.TimeToString(project.Created)
 
-	progressEvent, err := updateProjectSettings(currentModel, client)
+	currentModel.Id = project.Id
+	currentModel.Created = &formattedCreated
+	currentModel.ClusterCount = util.Int64PtrToIntPtr(&project.ClusterCount)
+
+	progressEvent, err := updateProjectSettings(currentModel, atlasV2)
 	if err != nil {
 		return progressEvent, err
 	}
-	event, proj, err := getProjectWithSettings(client, currentModel)
+	event, proj, err := getProjectWithSettings(atlasV2, currentModel)
 	if err != nil {
 		_, _ = logger.Warnf("getProject Error: %s", err)
 		return event, err
@@ -130,10 +139,10 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}, nil
 }
 
-func updateProjectSettings(currentModel *Model, client *mongodbatlas.Client) (handler.ProgressEvent, error) {
+func updateProjectSettings(currentModel *Model, atlasV2 *admin.APIClient) (handler.ProgressEvent, error) {
 	if currentModel.ProjectSettings != nil {
 		// Update project settings
-		projectSettings := mongodbatlas.ProjectSettings{
+		projectSettings := admin.GroupSettings{
 			IsCollectDatabaseSpecificsStatisticsEnabled: currentModel.ProjectSettings.IsCollectDatabaseSpecificsStatisticsEnabled,
 			IsRealtimePerformancePanelEnabled:           currentModel.ProjectSettings.IsRealtimePerformancePanelEnabled,
 			IsDataExplorerEnabled:                       currentModel.ProjectSettings.IsDataExplorerEnabled,
@@ -142,11 +151,11 @@ func updateProjectSettings(currentModel *Model, client *mongodbatlas.Client) (ha
 			IsExtendedStorageSizesEnabled:               currentModel.ProjectSettings.IsExtendedStorageSizesEnabled,
 		}
 
-		_, res, err := client.Projects.UpdateProjectSettings(context.Background(), *currentModel.Id, &projectSettings)
+		_, res, err := atlasV2.ProjectsApi.UpdateProjectSettings(context.Background(), *currentModel.Id, &projectSettings).Execute()
 		if err != nil {
 			_, _ = logger.Warnf("UpdateProjectSettings Error: %s", err)
 			return progressevents.GetFailedEventByResponse(fmt.Sprintf("Failed to update Project settings : %s", err.Error()),
-				res.Response), err
+				res), err
 		}
 	}
 	return handler.ProgressEvent{}, nil
@@ -159,13 +168,14 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
 		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
-	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
+	client, pe := util.NewAtlasClient(&req, currentModel.Profile)
+	atlasV2 := client.AtlasV2
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
 		return *pe, nil
 	}
 
-	event, model, err := getProjectWithSettings(client, currentModel)
+	event, model, err := getProjectWithSettings(atlasV2, currentModel)
 	if err != nil {
 		return event, nil
 	}
@@ -189,7 +199,8 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
 		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
-	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
+	client, pe := util.NewAtlasClient(&req, currentModel.Profile)
+	atlasV2 := client.AtlasV2
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
 		return *pe, nil
@@ -200,16 +211,16 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 		projectID = *currentModel.Id
 	}
 
-	event, _, err = getProject(client, currentModel)
+	event, _, err = getProject(atlasV2, currentModel)
 	if err != nil {
 		return event, nil
 	}
 
 	if currentModel.ProjectTeams != nil {
 		// Get teams from project
-		teamsAssigned, _, errr := client.Projects.GetProjectTeamsAssigned(context.Background(), projectID)
-		if errr != nil {
-			_, _ = logger.Warnf("ProjectId : %s, Error: %s", projectID, errr)
+		teamsAssigned, _, err := atlasV2.TeamsApi.ListProjectTeams(context.Background(), projectID).Execute()
+		if err != nil {
+			_, _ = logger.Warnf("ProjectId : %s, Error: %s", projectID, err)
 			return handler.ProgressEvent{
 				OperationStatus:  handler.Failed,
 				Message:          "Error while finding teams in project",
@@ -219,7 +230,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 
 		// Remove Teams
 		for _, team := range removeTeams {
-			_, err = client.Teams.RemoveTeamFromProject(context.Background(), projectID, team.TeamID)
+			_, err = atlasV2.TeamsApi.RemoveProjectTeam(context.Background(), projectID, util.SafeString(team.TeamId)).Execute()
 			if err != nil {
 				_, _ = logger.Warnf("ProjectId : %s, Error: %s", projectID, err)
 				return handler.ProgressEvent{
@@ -230,7 +241,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 		}
 		// Add Teams
 		if len(newTeams) > 0 {
-			_, _, err = client.Projects.AddTeamsToProject(context.Background(), projectID, newTeams)
+			_, _, err = atlasV2.TeamsApi.AddAllTeamsToProject(context.Background(), projectID, &newTeams).Execute()
 			if err != nil {
 				_, _ = logger.Warnf("Error: %s", err)
 				return handler.ProgressEvent{
@@ -241,7 +252,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 		}
 		// Update Teams
 		for _, team := range changedTeams {
-			_, _, err = client.Teams.UpdateTeamRoles(context.Background(), projectID, team.TeamID, &mongodbatlas.TeamUpdateRoles{RoleNames: team.RoleNames})
+			_, _, err = atlasV2.TeamsApi.UpdateTeamRoles(context.Background(), projectID, util.SafeString(team.TeamId), &admin.TeamRole{RoleNames: team.RoleNames}).Execute()
 			if err != nil {
 				_, _ = logger.Warnf("Error: %s", err)
 				return handler.ProgressEvent{
@@ -254,9 +265,13 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 
 	if currentModel.ProjectApiKeys != nil {
 		// Get APIKeys from project
-		projectAPIKeys, _, errr := client.ProjectAPIKeys.List(context.Background(), projectID, &mongodbatlas.ListOptions{ItemsPerPage: 1000, IncludeCount: true})
+		itemsPerPage := 1000
+		projectAPIKeys, _, err := atlasV2.ProgrammaticAPIKeysApi.ListProjectApiKeysWithParams(context.Background(), &admin.ListProjectApiKeysApiParams{
+			GroupId:      projectID,
+			ItemsPerPage: &itemsPerPage,
+		}).Execute()
 		if err != nil {
-			_, _ = logger.Warnf("ProjectId : %s, Error: %s", projectID, errr)
+			_, _ = logger.Warnf("ProjectId : %s, Error: %s", projectID, err)
 			return handler.ProgressEvent{
 				OperationStatus:  handler.Failed,
 				Message:          "Error while finding api keys in project",
@@ -264,11 +279,11 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 		}
 
 		// Get Change in ApiKeys
-		newAPIKeys, changedKeys, removeKeys := getChangeInAPIKeys(*currentModel.Id, currentModel.ProjectApiKeys, projectAPIKeys)
+		newAPIKeys, changedKeys, removeKeys := getChangeInAPIKeys(*currentModel.Id, currentModel.ProjectApiKeys, projectAPIKeys.Results)
 
 		// Remove old keys
 		for _, key := range removeKeys {
-			_, err = client.ProjectAPIKeys.Unassign(context.Background(), projectID, key.Key)
+			_, _, err = atlasV2.ProgrammaticAPIKeysApi.RemoveProjectApiKey(context.Background(), projectID, key.Key).Execute()
 			if err != nil {
 				_, _ = logger.Warnf("Error: %s", err)
 				return handler.ProgressEvent{
@@ -280,7 +295,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 
 		// Add Keys
 		for _, key := range newAPIKeys {
-			_, err = client.ProjectAPIKeys.Assign(context.Background(), projectID, key.Key, key.APIKeys)
+			_, _, err := atlasV2.ProgrammaticAPIKeysApi.UpdateApiKeyRoles(context.Background(), projectID, key.Key, key.UpdatePayload).Execute()
 			if err != nil {
 				_, _ = logger.Warnf("Error: %s", err)
 				return handler.ProgressEvent{
@@ -292,23 +307,23 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (event h
 
 		// Update Key Roles
 		for _, key := range changedKeys {
-			_, err = client.ProjectAPIKeys.Assign(context.Background(), projectID, key.Key, key.APIKeys)
+			_, _, err := atlasV2.ProgrammaticAPIKeysApi.UpdateApiKeyRoles(context.Background(), projectID, key.Key, key.UpdatePayload).Execute()
 			if err != nil {
 				_, _ = logger.Warnf("Error: %s", err)
 				return handler.ProgressEvent{
 					OperationStatus:  handler.Failed,
-					Message:          "Error while Un-assigning Key to project",
+					Message:          "Error while Assigning Key to project",
 					HandlerErrorCode: cloudformation.HandlerErrorCodeInvalidRequest}, nil
 			}
 		}
 	}
 
-	progressEvent, err := updateProjectSettings(currentModel, client)
+	progressEvent, err := updateProjectSettings(currentModel, atlasV2)
 	if err != nil {
 		return progressEvent, err
 	}
 
-	event, project, err := getProjectWithSettings(client, currentModel)
+	event, project, err := getProjectWithSettings(atlasV2, currentModel)
 	if err != nil {
 		return event, err
 	}
@@ -327,7 +342,8 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (event h
 	if currentModel.Profile == nil || *currentModel.Profile == "" {
 		currentModel.Profile = aws.String(profile.DefaultProfile)
 	}
-	client, pe := util.NewMongoDBClient(req, currentModel.Profile)
+	client, pe := util.NewAtlasClient(&req, currentModel.Profile)
+	atlasV2 := client.AtlasV2
 	if pe != nil {
 		_, _ = logger.Warnf("CreateMongoDBClient error: %v", *pe)
 		return *pe, nil
@@ -337,17 +353,17 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (event h
 		id = *currentModel.Id
 	}
 
-	event, _, err = getProject(client, currentModel)
+	event, _, err = getProject(atlasV2, currentModel)
 	if err != nil {
 		return event, nil
 	}
 	_, _ = logger.Debugf("Deleting project with id(%s)", id)
 
-	res, err := client.Projects.Delete(context.Background(), id)
+	_, res, err := atlasV2.ProjectsApi.DeleteProject(context.Background(), id).Execute()
 	if err != nil {
 		_, _ = logger.Warnf("####error deleting project with id(%s): %s", id, err)
 		return progressevents.GetFailedEventByResponse(fmt.Sprintf("Failed to Create Project : %s", err.Error()),
-			res.Response), nil
+			res), nil
 	}
 
 	return handler.ProgressEvent{
@@ -363,8 +379,8 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 }
 
 // Read project
-func getProject(client *mongodbatlas.Client, currentModel *Model) (event handler.ProgressEvent, model *Model, err error) {
-	var project *mongodbatlas.Project
+func getProject(client *admin.APIClient, currentModel *Model) (event handler.ProgressEvent, model *Model, err error) {
+	var project *admin.Group
 	if currentModel.Name != nil && len(*currentModel.Name) > 0 {
 		event, project, err = getProjectByName(currentModel.Name, client)
 		if err != nil {
@@ -376,22 +392,24 @@ func getProject(client *mongodbatlas.Client, currentModel *Model) (event handler
 			return event, nil, err
 		}
 	}
+	formattedCreated := util.TimeToString(project.Created)
+
 	currentModel.Name = &project.Name
-	currentModel.OrgId = &project.OrgID
-	currentModel.Created = &project.Created
-	currentModel.ClusterCount = &project.ClusterCount
-	currentModel.Id = &project.ID
-	currentModel.RegionUsageRestrictions = &project.RegionUsageRestrictions
+	currentModel.OrgId = &project.OrgId
+	currentModel.Created = &formattedCreated
+	currentModel.ClusterCount = util.Int64PtrToIntPtr(&project.ClusterCount)
+	currentModel.Id = project.Id
+	currentModel.RegionUsageRestrictions = project.RegionUsageRestrictions
 	return handler.ProgressEvent{}, currentModel, nil
 }
 
 // Read project
-func getProjectWithSettings(client *mongodbatlas.Client, currentModel *Model) (event handler.ProgressEvent, model *Model, err error) {
-	event, currentModel, err = getProject(client, currentModel)
+func getProjectWithSettings(atlasV2 *admin.APIClient, currentModel *Model) (event handler.ProgressEvent, model *Model, err error) {
+	event, currentModel, err = getProject(atlasV2, currentModel)
 	if err != nil {
 		return event, currentModel, err
 	}
-	event, model, err = readProjectSettings(client, *currentModel.Id, currentModel)
+	event, model, err = readProjectSettings(atlasV2, *currentModel.Id, currentModel)
 
 	if err != nil {
 		return event, model, err
@@ -400,48 +418,48 @@ func getProjectWithSettings(client *mongodbatlas.Client, currentModel *Model) (e
 	return handler.ProgressEvent{}, model, nil
 }
 
-func getProjectByName(name *string, client *mongodbatlas.Client) (event handler.ProgressEvent, model *mongodbatlas.Project, err error) {
-	project, res, err := client.Projects.GetOneProjectByName(context.Background(), *name)
+func getProjectByName(name *string, client *admin.APIClient) (event handler.ProgressEvent, model *admin.Group, err error) {
+	project, res, err := client.ProjectsApi.GetProjectByName(context.Background(), *name).Execute()
 	if err != nil {
-		if res.Response.StatusCode == 401 { // cfn test
+		if res.StatusCode == 401 { // cfn test
 			return progressevents.GetFailedEventByCode(
 				"Unauthorized Error: Unable to retrieve Project by name. Please verify that the API keys provided in the profile have sufficient privileges to access the project.",
 				cloudformation.HandlerErrorCodeNotFound), nil, err
 		}
 		return progressevents.GetFailedEventByResponse(err.Error(),
-			res.Response), project, err
+			res), project, err
 	}
 	return handler.ProgressEvent{}, project, err
 }
 
-func getProjectByID(id *string, client *mongodbatlas.Client) (event handler.ProgressEvent, model *mongodbatlas.Project, err error) {
-	project, res, err := client.Projects.GetOneProject(context.Background(), *id)
+func getProjectByID(id *string, atlasV2 *admin.APIClient) (event handler.ProgressEvent, model *admin.Group, err error) {
+	project, res, err := atlasV2.ProjectsApi.GetProject(context.Background(), *id).Execute()
 	if err != nil {
-		if res.Response.StatusCode == 401 { // cfn test
+		if res.StatusCode == 401 { // cfn test
 			return progressevents.GetFailedEventByCode(
 				"Unauthorized Error: Unable to retrieve Project by ID. Please verify that the API keys provided in the profile have sufficient privileges to access the project.",
 				cloudformation.HandlerErrorCodeNotFound), nil, err
 		}
 		return progressevents.GetFailedEventByResponse(err.Error(),
-			res.Response), project, err
+			res), project, err
 	}
 	return handler.ProgressEvent{}, project, err
 }
 
-func readProjectSettings(client *mongodbatlas.Client, id string, currentModel *Model) (event handler.ProgressEvent, model *Model, err error) {
+func readProjectSettings(atlasV2 *admin.APIClient, id string, currentModel *Model) (event handler.ProgressEvent, model *Model, err error) {
 	// Get teams from project
-	teamsAssigned, res, err := client.Projects.GetProjectTeamsAssigned(context.Background(), id)
+	teamsAssigned, res, err := atlasV2.TeamsApi.ListProjectTeams(context.Background(), id).Execute()
 	if err != nil {
 		_, _ = logger.Warnf("ProjectId : %s, Error: %s", id, err)
 		return progressevents.GetFailedEventByResponse(err.Error(),
-			res.Response), nil, err
+			res), nil, err
 	}
 
-	projectSettings, _, err := client.Projects.GetProjectSettings(context.Background(), id)
+	projectSettings, _, err := atlasV2.ProjectsApi.GetProjectSettings(context.Background(), id).Execute()
 	if err != nil {
 		_, _ = logger.Warnf("ProjectId : %s, Error: %s", id, err)
 		return progressevents.GetFailedEventByResponse(err.Error(),
-			res.Response), nil, err
+			res), nil, err
 	}
 	// Set projectSettings
 	currentModel.ProjectSettings = &ProjectSettings{
@@ -456,8 +474,8 @@ func readProjectSettings(client *mongodbatlas.Client, id string, currentModel *M
 	// Set teams
 	var teams []ProjectTeam
 	for _, team := range teamsAssigned.Results {
-		if len(team.TeamID) > 0 {
-			teams = append(teams, ProjectTeam{TeamId: &team.TeamID, RoleNames: team.RoleNames})
+		if team.TeamId != nil && len(*team.TeamId) > 0 {
+			teams = append(teams, ProjectTeam{TeamId: team.TeamId, RoleNames: team.RoleNames})
 		}
 	}
 
@@ -467,36 +485,36 @@ func readProjectSettings(client *mongodbatlas.Client, id string, currentModel *M
 }
 
 // Get difference in Teams
-func getChangeInTeams(currentTeams []ProjectTeam, oTeams []*mongodbatlas.Result) (newTeams []*mongodbatlas.ProjectTeam,
-	changedTeams []*mongodbatlas.ProjectTeam, removeTeams []*mongodbatlas.ProjectTeam) {
+func getChangeInTeams(currentTeams []ProjectTeam, oTeams []admin.TeamRole) (newTeams []admin.TeamRole,
+	changedTeams []admin.TeamRole, removeTeams []admin.TeamRole) {
 	for _, nTeam := range currentTeams {
 		if nTeam.TeamId != nil && len(*nTeam.TeamId) > 0 {
 			matched := false
 			for _, oTeam := range oTeams {
-				if nTeam.TeamId != nil && *nTeam.TeamId == oTeam.TeamID {
-					changedTeams = append(changedTeams, &mongodbatlas.ProjectTeam{TeamID: *nTeam.TeamId, RoleNames: nTeam.RoleNames})
+				if nTeam.TeamId != nil && oTeam.TeamId != nil && *nTeam.TeamId == *oTeam.TeamId {
+					changedTeams = append(changedTeams, admin.TeamRole{TeamId: nTeam.TeamId, RoleNames: nTeam.RoleNames})
 					matched = true
 					break
 				}
 			}
 			// Add to newTeams
 			if !matched {
-				newTeams = append(newTeams, &mongodbatlas.ProjectTeam{TeamID: *nTeam.TeamId, RoleNames: nTeam.RoleNames})
+				newTeams = append(newTeams, admin.TeamRole{TeamId: nTeam.TeamId, RoleNames: nTeam.RoleNames})
 			}
 		}
 	}
 
 	for _, oTeam := range oTeams {
-		if len(oTeam.TeamID) > 0 {
+		if oTeam.TeamId != nil && len(*oTeam.TeamId) > 0 {
 			matched := false
 			for _, nTeam := range currentTeams {
-				if nTeam.TeamId != nil && *nTeam.TeamId == oTeam.TeamID {
+				if nTeam.TeamId != nil && oTeam.TeamId != nil && *nTeam.TeamId == *oTeam.TeamId {
 					matched = true
 					break
 				}
 			}
 			if !matched {
-				removeTeams = append(removeTeams, &mongodbatlas.ProjectTeam{TeamID: oTeam.TeamID, RoleNames: oTeam.RoleNames})
+				removeTeams = append(removeTeams, admin.TeamRole{TeamId: oTeam.TeamId, RoleNames: oTeam.RoleNames})
 			}
 		}
 	}
@@ -504,29 +522,29 @@ func getChangeInTeams(currentTeams []ProjectTeam, oTeams []*mongodbatlas.Result)
 }
 
 // Get difference in ApiKeys
-func getChangeInAPIKeys(groupID string, currentKeys []ProjectApiKey, oKeys []mongodbatlas.APIKey) (newKeys, changedKeys, removeKeys []UpdateAPIKey) {
+func getChangeInAPIKeys(groupID string, currentKeys []ProjectApiKey, oKeys []admin.ApiKeyUserDetails) (newKeys, changedKeys, removeKeys []UpdateAPIKey) {
 	for _, nKey := range currentKeys {
 		if nKey.Key != nil && len(*nKey.Key) > 0 {
 			matched := false
 			for _, oKey := range oKeys {
-				if nKey.Key != nil && *nKey.Key == oKey.ID {
-					changedKeys = append(changedKeys, UpdateAPIKey{Key: *nKey.Key, APIKeys: &mongodbatlas.AssignAPIKey{Roles: nKey.RoleNames}})
+				if nKey.Key != nil && oKey.Id != nil && *nKey.Key == *oKey.Id {
+					changedKeys = append(changedKeys, UpdateAPIKey{Key: *nKey.Key, UpdatePayload: &admin.UpdateAtlasProjectApiKey{Roles: nKey.RoleNames}})
 					matched = true
 					break
 				}
 			}
 			// Add to newKeys
 			if !matched {
-				newKeys = append(newKeys, UpdateAPIKey{Key: *nKey.Key, APIKeys: &mongodbatlas.AssignAPIKey{Roles: nKey.RoleNames}})
+				newKeys = append(newKeys, UpdateAPIKey{Key: *nKey.Key, UpdatePayload: &admin.UpdateAtlasProjectApiKey{Roles: nKey.RoleNames}})
 			}
 		}
 	}
 
 	for _, oKey := range oKeys {
-		if len(oKey.ID) > 0 {
+		if oKey.Id != nil && len(*oKey.Id) > 0 {
 			matched := false
 			for _, nKey := range currentKeys {
-				if nKey.Key != nil && *nKey.Key == oKey.ID {
+				if nKey.Key != nil && *nKey.Key == *oKey.Id {
 					matched = true
 					break
 				}
@@ -534,8 +552,8 @@ func getChangeInAPIKeys(groupID string, currentKeys []ProjectApiKey, oKeys []mon
 			if !matched {
 				for _, role := range oKey.Roles {
 					// Consider only current ProjectRoles
-					if role.GroupID == groupID {
-						removeKeys = append(removeKeys, UpdateAPIKey{Key: oKey.ID})
+					if role.GroupId != nil && *role.GroupId == groupID {
+						removeKeys = append(removeKeys, UpdateAPIKey{Key: *oKey.Id})
 					}
 				}
 			}
@@ -544,11 +562,11 @@ func getChangeInAPIKeys(groupID string, currentKeys []ProjectApiKey, oKeys []mon
 	return newKeys, changedKeys, removeKeys
 }
 
-func readTeams(teams []ProjectTeam) []*mongodbatlas.ProjectTeam {
-	var newTeams []*mongodbatlas.ProjectTeam
+func readTeams(teams []ProjectTeam) []admin.TeamRole {
+	var newTeams []admin.TeamRole
 	for _, t := range teams {
 		if t.TeamId != nil && len(*t.TeamId) > 0 {
-			newTeams = append(newTeams, &mongodbatlas.ProjectTeam{TeamID: *t.TeamId, RoleNames: t.RoleNames})
+			newTeams = append(newTeams, admin.TeamRole{TeamId: t.TeamId, RoleNames: t.RoleNames})
 		}
 	}
 	return newTeams

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -398,3 +398,17 @@ func Int64PtrToIntPtr(i64 *int64) *int {
 	i := int(*i64)
 	return &i
 }
+
+func IsStringPresent(strPtr *string) bool {
+	return strPtr != nil && len(*strPtr) > 0
+}
+
+func AreStringPtrEqual(p1, p2 *string) bool {
+	if p1 == nil {
+		return p2 == nil
+	}
+	if p2 == nil {
+		return false
+	}
+	return *p1 == *p2
+}

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -389,3 +389,12 @@ func TimePtrToStringPtr(t *time.Time) *string {
 func TimeToString(t time.Time) string {
 	return t.UTC().Format(time.RFC3339Nano)
 }
+
+func Int64PtrToIntPtr(i64 *int64) *int {
+	if i64 == nil {
+		return nil
+	}
+
+	i := int(*i64)
+	return &i
+}

--- a/cfn-resources/util/util_test.go
+++ b/cfn-resources/util/util_test.go
@@ -1,0 +1,66 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
+)
+
+var (
+	empty    = ""
+	oneBlank = " "
+	str      = "text"
+)
+
+func TestIsStringPresent(t *testing.T) {
+	tests := []struct {
+		strPtr   *string
+		expected bool
+	}{
+		{nil, false},
+		{&empty, false},
+		{&oneBlank, true},
+		{&str, true},
+	}
+	for _, test := range tests {
+		if resp := util.IsStringPresent(test.strPtr); resp != test.expected {
+			t.Errorf("IsStringPresent(%v) = %v; want %v", test.strPtr, resp, test.expected)
+		}
+	}
+}
+
+func TestAreStringPtrEqual(t *testing.T) {
+	tests := []struct {
+		strPtr1  *string
+		strPtr2  *string
+		expected bool
+	}{
+		{nil, &empty, false},
+		{&empty, nil, false},
+		{&oneBlank, &empty, false},
+		{&empty, &oneBlank, false},
+		{nil, nil, true},
+		{&empty, &empty, true},
+		{&oneBlank, &oneBlank, true},
+		{&str, &str, true},
+	}
+	for _, test := range tests {
+		if resp := util.AreStringPtrEqual(test.strPtr1, test.strPtr2); resp != test.expected {
+			t.Errorf("AreStringPtrEqual(%v, %v) = %v; want %v", test.strPtr1, test.strPtr2, resp, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [INTMDB-1102](https://jira.mongodb.org/browse/INTMDB-1102)

Migrating project resource to new Atlas SDK.

**Note**: A potential bug was detected when verifying the update of API keys in the project resource. This bug is not related the sdk migration changes, verified with public extension that it is already present.
On creation, if an API key is defined it will be registered together with the key that is creating the project (defined with project owner permissions). When doing an update, the updated project api key defined is set correctly, but the default project owner key is removed. Created ticket [INTMDB-1128](https://jira.mongodb.org/browse/INTMDB-1128) to triage and see if we want to adjust this behaviour.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

**Contract testing:**
![contract testing](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/39ef0b26-f840-444d-adcd-5105622eb855)

**Automated E2E testing:**
![e2e tests](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/4940f063-804d-4c6b-8d2d-d40705a36f5c)

**Manual testing creating/updating/deleting stack using private registry:**
![stack history](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/b497074a-bd1c-4433-aa7b-94dbbf8b5763)

- after creation:
![success creation with teams](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/0ab07320-a7b4-4629-a755-8066c20d9ddc)
![success creation with api keys](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/6ba751f4-ba0d-46c3-a800-72870031b863)

- after update with different key and team id:
<img width="975" alt="team after update" src="https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/d91253a8-12de-45c0-9bb4-000e2ac064a4">
<img width="1111" alt="keys after update" src="https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/8bfc3900-e588-41f5-9bae-19bd53783765">


