### PR TITLE
fix: fixed deploy for multiple resources

### DIFF
--- a/cfn-resources/access-list-api-key/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/access-list-api-key/test/cfn-test-create-inputs.sh
@@ -26,15 +26,15 @@ echo "profile set to ${MONGODB_ATLAS_PROFILE}"
 Profile=${MONGODB_ATLAS_PROFILE}
 fi
 
-# Check MONGODB_ATLAS_ORG_ID is set
-if [ -z "${MONGODB_ATLAS_ORG_ID+x}" ];then
-  if [ -z "${ATLAS_ORG_ID+x}" ];then
-    if
+# Check if MONGODB_ATLAS_ORG_ID is set
+if [ -z "${MONGODB_ATLAS_ORG_ID+x}" ]; then
+  # Check if ATLAS_ORG_ID is set as a fallback
+  if [ -z "${ATLAS_ORG_ID+x}" ]; then
     echo "MONGODB_ATLAS_ORG_ID or ATLAS_ORG_ID must be set"
     exit 1
+  else
+    MONGODB_ATLAS_ORG_ID="$ATLAS_ORG_ID"
   fi
-  MONGODB_ATLAS_ORG_ID = $ATLAS_ORG_ID
-  exit 1
 fi
 
 OrgId="${MONGODB_ATLAS_ORG_ID}"

--- a/cfn-resources/access-list-api-key/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/access-list-api-key/test/cfn-test-create-inputs.sh
@@ -25,9 +25,15 @@ if [ ${MONGODB_ATLAS_PROFILE+x} ];then
 echo "profile set to ${MONGODB_ATLAS_PROFILE}"
 Profile=${MONGODB_ATLAS_PROFILE}
 fi
+
 # Check MONGODB_ATLAS_ORG_ID is set
 if [ -z "${MONGODB_ATLAS_ORG_ID+x}" ];then
-  echo "MONGODB_ATLAS_ORG_ID must be set"
+  if [ -z "${ATLAS_ORG_ID+x}" ];then
+    if
+    echo "MONGODB_ATLAS_ORG_ID or ATLAS_ORG_ID must be set"
+    exit 1
+  fi
+  MONGODB_ATLAS_ORG_ID = $ATLAS_ORG_ID
   exit 1
 fi
 

--- a/cfn-resources/api-key/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/api-key/test/cfn-test-create-inputs.sh
@@ -37,7 +37,7 @@ if [ -z "${MONGODB_ATLAS_ORG_ID+x}" ]; then
   fi
 fi
 
-OrgId="${MONGODB_ATLAS_ORG_ID}"
+orgId="${MONGODB_ATLAS_ORG_ID}"
 
 # create ProjectId
 projectName="${1}"

--- a/cfn-resources/api-key/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/api-key/test/cfn-test-create-inputs.sh
@@ -26,15 +26,15 @@ if [ ${MONGODB_ATLAS_PROFILE+x} ];then
     profile=${MONGODB_ATLAS_PROFILE}
 fi
 
-# Check MONGODB_ATLAS_ORG_ID is set
-if [ -z "${MONGODB_ATLAS_ORG_ID+x}" ];then
-  if [ -z "${ATLAS_ORG_ID+x}" ];then
-    if
+# Check if MONGODB_ATLAS_ORG_ID is set
+if [ -z "${MONGODB_ATLAS_ORG_ID+x}" ]; then
+  # Check if ATLAS_ORG_ID is set as a fallback
+  if [ -z "${ATLAS_ORG_ID+x}" ]; then
     echo "MONGODB_ATLAS_ORG_ID or ATLAS_ORG_ID must be set"
     exit 1
+  else
+    MONGODB_ATLAS_ORG_ID="$ATLAS_ORG_ID"
   fi
-  MONGODB_ATLAS_ORG_ID = $ATLAS_ORG_ID
-  exit 1
 fi
 
 OrgId="${MONGODB_ATLAS_ORG_ID}"

--- a/cfn-resources/api-key/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/api-key/test/cfn-test-create-inputs.sh
@@ -25,13 +25,19 @@ if [ ${MONGODB_ATLAS_PROFILE+x} ];then
     echo "profile set to ${MONGODB_ATLAS_PROFILE}"
     profile=${MONGODB_ATLAS_PROFILE}
 fi
+
 # Check MONGODB_ATLAS_ORG_ID is set
 if [ -z "${MONGODB_ATLAS_ORG_ID+x}" ];then
-  echo "MONGODB_ATLAS_ORG_ID must be set"
+  if [ -z "${ATLAS_ORG_ID+x}" ];then
+    if
+    echo "MONGODB_ATLAS_ORG_ID or ATLAS_ORG_ID must be set"
+    exit 1
+  fi
+  MONGODB_ATLAS_ORG_ID = $ATLAS_ORG_ID
   exit 1
 fi
 
-orgId="${MONGODB_ATLAS_ORG_ID}"
+OrgId="${MONGODB_ATLAS_ORG_ID}"
 
 # create ProjectId
 projectName="${1}"

--- a/cfn-resources/datalakes/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/datalakes/test/cfn-test-create-inputs.sh
@@ -77,15 +77,15 @@ aws s3 mb "s3://${bucketName}" --output json
 echo -e "--------------------------------create aws bucket document  ends ----------------------------\n"
 
 
-roleID=$(atlas cloudProviders accessRoles aws create --output json | jq -r '.roleId')
+roleID=$(atlas cloudProviders accessRoles aws create --projectId "${projectId}" --output json | jq -r '.roleId')
 echo -e "--------------------------------Mongo CLI Role creation ends ----------------------------\n"
 
 echo -e "--------------------------------printing mongodb role details ----------------------------\n"
-atlas cloudProviders accessRoles  list --output json | jq --arg NAME "${projectName}" -r '.awsIamRoles[] |select(.iamAssumedRoleArn |test( "mongodb-test-export-role$")?)'
+atlas cloudProviders accessRoles  list --projectId "${projectId}" --output json | jq --arg NAME "${projectName}" -r '.awsIamRoles[] |select(.iamAssumedRoleArn |test( "mongodb-test-export-role$")?)'
 echo -e "--------------------------------AWS Role policy creation starts ----------------------------\n"
 
-atlasAWSAccountArn=$(atlas cloudProviders accessRoles  list --output json | jq --arg roleID "${roleID}" -r '.awsIamRoles[] |select(.roleId |test( $roleID)) |.atlasAWSAccountArn')
-atlasAssumedRoleExternalId=$(atlas cloudProviders accessRoles  list --output json | jq --arg roleID "${roleID}" -r '.awsIamRoles[] |select(.roleId |test( $roleID)) |.atlasAssumedRoleExternalId')
+atlasAWSAccountArn=$(atlas cloudProviders accessRoles  list --projectId "${projectId}" --output json | jq --arg roleID "${roleID}" -r '.awsIamRoles[] |select(.roleId |test( $roleID)) |.atlasAWSAccountArn')
+atlasAssumedRoleExternalId=$(atlas cloudProviders accessRoles  list --projectId "${projectId}" --output json | jq --arg roleID "${roleID}" -r '.awsIamRoles[] |select(.roleId |test( $roleID)) |.atlasAssumedRoleExternalId')
 jq --arg atlasAssumedRoleExternalId "$atlasAssumedRoleExternalId" \
    --arg atlasAWSAccountArn "$atlasAWSAccountArn" \
   '.Statement[0].Principal.AWS?|=$atlasAWSAccountArn | .Statement[0].Condition.StringEquals["sts:ExternalId"]?|=$atlasAssumedRoleExternalId' "$(dirname "$0")/role-policy-template.json" >"$(dirname "$0")/add-policy.json"
@@ -119,7 +119,7 @@ awsArne=$(echo "${awsArn}" | sed 's/"//g')
 # TODO Needs change to while loop using get operation
 sleep 65
 
-atlas cloudProviders accessRoles aws authorize "${roleID}" --iamAssumedRoleArn "${awsArne}"
+atlas cloudProviders accessRoles aws authorize "${roleID}" --projectId "${projectId}" --iamAssumedRoleArn "${awsArne}"
 echo -e "--------------------------------authorize mongodb  Role ends ----------------------------\n"
 
 jq --arg org "$ATLAS_ORG_ID" \

--- a/cfn-resources/datalakes/test/cfn-test-delete-inputs.sh
+++ b/cfn-resources/datalakes/test/cfn-test-delete-inputs.sh
@@ -21,7 +21,6 @@ clusters_response=$(atlas clusters list --projectId "$project_id" 2>&1)
 # Check if the response contains the "GROUP_NOT_FOUND" error message
 if [[ "$clusters_response" == *"GROUP_NOT_FOUND"* ]]; then
     echo "Project with ID $project_id not found. Continuing with the next project."
-    continue
 fi
 
 total_count=$(echo "$clusters_response" | jq -r '.totalCount')
@@ -31,7 +30,7 @@ if [ "$total_count" -eq 0 ]; then
     echo "No clusters found for project with ID: $project_id"
 else
     # Extract cluster names from the response
-    cluster_names=($(echo "$clusters_response" | jq -r '.results[].name'))
+    mapfile -t cluster_names < <(echo "$clusters_response" | jq -r '.results[].name')
 
     # Delete each cluster within the project
     for cluster_name in "${cluster_names[@]}"; do

--- a/cfn-resources/datalakes/test/cfn-test-delete-inputs.sh
+++ b/cfn-resources/datalakes/test/cfn-test-delete-inputs.sh
@@ -7,16 +7,56 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -x
 
 function usage {
 	echo "usage:$0 "
 }
 
-projectId=$(jq -r '.ProjectId' ./inputs/inputs_1_create.json)
+project_id=$(jq -r '.ProjectId' ./inputs/inputs_1_create.json)
+
+# Get a list of clusters for the current project
+clusters_response=$(atlas clusters list --projectId "$project_id" 2>&1)
+
+# Check if the response contains the "GROUP_NOT_FOUND" error message
+if [[ "$clusters_response" == *"GROUP_NOT_FOUND"* ]]; then
+    echo "Project with ID $project_id not found. Continuing with the next project."
+    continue
+fi
+
+total_count=$(echo "$clusters_response" | jq -r '.totalCount')
+
+# Check if there are clusters for the project
+if [ "$total_count" -eq 0 ]; then
+    echo "No clusters found for project with ID: $project_id"
+else
+    # Extract cluster names from the response
+    cluster_names=($(echo "$clusters_response" | jq -r '.results[].name'))
+
+    # Delete each cluster within the project
+    for cluster_name in "${cluster_names[@]}"; do
+        echo "Deleting cluster with name: $cluster_name"
+        atlas clusters delete "$cluster_name" --projectId "$project_id" --force
+
+        echo "Waiting for cluster to get deleted"
+        status=$(atlas clusters describe "${cluster_name}" --projectId "${project_id}" --output=json | jq -r '.stateName')
+        echo "status: ${status}"
+
+        while [[ "${status}" == "DELETING" ]]; do
+            sleep 30
+            if atlas clusters describe "${cluster_name}" --projectId "${project_id}"; then
+                status=$(atlas clusters describe "${cluster_name}" --projectId "${project_id}" --output=json | jq -r '.stateName')
+            else
+                status="DELETED"
+            fi
+            echo "status: ${status}"
+        done
+    done
+fi
 
 #delete project
-if mongocli iam projects delete "$projectId" --force; then
-	echo "$projectId project deletion OK"
+if atlas projects delete "$project_id" --force; then
+	echo "$project_id project deletion OK"
 else
-	(echo "Failed cleaning project:$projectId" && exit 1)
+	(echo "Failed cleaning project:$project_id" && exit 1)
 fi

--- a/cfn-resources/federated-settings-org-role-mapping/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/federated-settings-org-role-mapping/test/cfn-test-create-inputs.sh
@@ -14,6 +14,13 @@ function usage {
 	echo "usage:$0 <project_name>"
 }
 
+#set profile
+profile="federation"
+if [ ${MONGODB_ATLAS_PROFILE+x} ];then
+    echo "profile set to ${MONGODB_ATLAS_PROFILE}"
+    profile=${MONGODB_ATLAS_PROFILE}
+fi
+
 projectName="${1}"
 projectId=$(atlas projects list --output json | jq --arg NAME "${projectName}" -r '.results[] | select(.name==$NAME) | .id')
 if [ -z "$projectId" ]; then
@@ -36,7 +43,8 @@ for inputFile in inputs_*; do
 	jq --arg org "$ATLAS_ORG_ID" \
 		--arg FederationSettingsId "$ATLAS_FEDERATED_SETTINGS_ID" \
 		--arg projectId "$projectId" \
-		'.FederationSettingsId?|=$FederationSettingsId | .OrgId?|=$org | .RoleAssignments[0].ProjectId?|=$projectId' \
+		--arg profile "$profile" \
+		'.Profile?|=$profile | .FederationSettingsId?|=$FederationSettingsId | .OrgId?|=$org | .RoleAssignments[0].ProjectId?|=$projectId' \
 		"$inputFile" >"../inputs/$outputFile"
 done
 cd ..

--- a/cfn-resources/federated-settings-org-role-mapping/test/inputs_1_create.template.json
+++ b/cfn-resources/federated-settings-org-role-mapping/test/inputs_1_create.template.json
@@ -1,5 +1,5 @@
 {
-  "Profile": "default",
+  "Profile": "federation",
   "FederationSettingsId": "",
   "OrgId": "",
   "ExternalGroupName": "RM-01",

--- a/cfn-resources/maintenance-window/docs/README.md
+++ b/cfn-resources/maintenance-window/docs/README.md
@@ -12,7 +12,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "MongoDB::Atlas::MaintenanceWindow",
     "Properties" : {
-        "<a href="#profile" title="Profile">Profile</a>" : <i>String</i>,
         "<a href="#autodeferonceenabled" title="AutoDeferOnceEnabled">AutoDeferOnceEnabled</a>" : <i>Boolean</i>,
         "<a href="#dayofweek" title="DayOfWeek">DayOfWeek</a>" : <i>Integer</i>,
         "<a href="#projectid" title="ProjectId">ProjectId</a>" : <i>String</i>,
@@ -27,7 +26,6 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: MongoDB::Atlas::MaintenanceWindow
 Properties:
-    <a href="#profile" title="Profile">Profile</a>: <i>String</i>
     <a href="#autodeferonceenabled" title="AutoDeferOnceEnabled">AutoDeferOnceEnabled</a>: <i>Boolean</i>
     <a href="#dayofweek" title="DayOfWeek">DayOfWeek</a>: <i>Integer</i>
     <a href="#projectid" title="ProjectId">ProjectId</a>: <i>String</i>
@@ -36,16 +34,6 @@ Properties:
 </pre>
 
 ## Properties
-
-#### Profile
-
-The profile is defined in AWS Secret manager. See [Secret Manager Profile setup](../../../examples/profile-secret.yaml)
-
-_Required_: No
-
-_Type_: String
-
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### AutoDeferOnceEnabled
 
@@ -113,4 +101,16 @@ _Required_: No
 _Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+## Return Values
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### Profile
+
+The profile is defined in AWS Secret manager. See [Secret Manager Profile setup](../../../examples/profile-secret.yaml)
 

--- a/cfn-resources/maintenance-window/docs/README.md
+++ b/cfn-resources/maintenance-window/docs/README.md
@@ -12,6 +12,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 {
     "Type" : "MongoDB::Atlas::MaintenanceWindow",
     "Properties" : {
+        "<a href="#profile" title="Profile">Profile</a>" : <i>String</i>,
         "<a href="#autodeferonceenabled" title="AutoDeferOnceEnabled">AutoDeferOnceEnabled</a>" : <i>Boolean</i>,
         "<a href="#dayofweek" title="DayOfWeek">DayOfWeek</a>" : <i>Integer</i>,
         "<a href="#projectid" title="ProjectId">ProjectId</a>" : <i>String</i>,
@@ -26,6 +27,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 <pre>
 Type: MongoDB::Atlas::MaintenanceWindow
 Properties:
+    <a href="#profile" title="Profile">Profile</a>: <i>String</i>
     <a href="#autodeferonceenabled" title="AutoDeferOnceEnabled">AutoDeferOnceEnabled</a>: <i>Boolean</i>
     <a href="#dayofweek" title="DayOfWeek">DayOfWeek</a>: <i>Integer</i>
     <a href="#projectid" title="ProjectId">ProjectId</a>: <i>String</i>
@@ -34,6 +36,16 @@ Properties:
 </pre>
 
 ## Properties
+
+#### Profile
+
+The profile is defined in AWS Secret manager. See [Secret Manager Profile setup](../../../examples/profile-secret.yaml)
+
+_Required_: No
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### AutoDeferOnceEnabled
 
@@ -101,16 +113,4 @@ _Required_: No
 _Type_: Boolean
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
-
-## Return Values
-
-### Fn::GetAtt
-
-The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
-
-For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
-
-#### Profile
-
-The profile is defined in AWS Secret manager. See [Secret Manager Profile setup](../../../examples/profile-secret.yaml)
 

--- a/cfn-resources/maintenance-window/mongodb-atlas-maintenancewindow.json
+++ b/cfn-resources/maintenance-window/mongodb-atlas-maintenancewindow.json
@@ -58,9 +58,7 @@
     }
   },
   "createOnlyProperties": [
-    "/properties/ProjectId"
-  ],
-  "readOnlyProperties": [
+    "/properties/ProjectId",
     "/properties/Profile"
   ],
   "required": [

--- a/cfn-resources/maintenance-window/mongodb-atlas-maintenancewindow.json
+++ b/cfn-resources/maintenance-window/mongodb-atlas-maintenancewindow.json
@@ -58,8 +58,10 @@
     }
   },
   "createOnlyProperties": [
-    "/properties/Profile",
     "/properties/ProjectId"
+  ],
+  "readOnlyProperties": [
+    "/properties/Profile"
   ],
   "required": [
     "HourOfDay"

--- a/cfn-resources/maintenance-window/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/maintenance-window/test/cfn-test-create-inputs.sh
@@ -36,10 +36,6 @@ jq --arg project_id "$projectId" \
 
 jq --arg project_id "$projectId" \
 	'.ProjectId?|=$project_id' \
-	"$(dirname "$0")/inputs_1_invalid.template.json" >"inputs/inputs_1_invalid.json"
-
-jq --arg project_id "$projectId" \
-	'.ProjectId?|=$project_id' \
 	"$(dirname "$0")/inputs_1_update.template.json" >"inputs/inputs_1_update.json"
 
 ls -l inputs

--- a/cfn-resources/maintenance-window/test/inputs_1_create.template.json
+++ b/cfn-resources/maintenance-window/test/inputs_1_create.template.json
@@ -2,5 +2,5 @@
   "DayOfWeek": "4",
   "HourOfDay": "15",
   "ProjectId": "$ProjectId",
-  "Profile": ""
+  "Profile": "default"
 }

--- a/cfn-resources/maintenance-window/test/inputs_1_invalid.template.json
+++ b/cfn-resources/maintenance-window/test/inputs_1_invalid.template.json
@@ -1,6 +1,0 @@
-{
-  "DayOfWeek": "9999",
-  "HourOfDay": "99999",
-  "ProjectId": "$ProjectId",
-  "Profile": ""
-}

--- a/cfn-resources/maintenance-window/test/inputs_1_update.template.json
+++ b/cfn-resources/maintenance-window/test/inputs_1_update.template.json
@@ -2,5 +2,5 @@
   "DayOfWeek": "1",
   "HourOfDay": "10",
   "ProjectId": "$ProjectId",
-  "Profile": ""
+  "Profile": "default"
 }

--- a/cfn-resources/private-endpoint-adl/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/private-endpoint-adl/test/cfn-test-create-inputs.sh
@@ -21,6 +21,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+set -x
+
 function usage {
 	echo "usage: cfn-test-create-inputs.sh <projectId> <endpoint>"
 	echo "Creates a new Search Index"
@@ -42,13 +44,61 @@ else
 	echo -e "FOUND project \"${projectName}\" with id: ${projectId}\n"
 fi
 
-endpoint="${2:-$AWS_VPC_ENDPOINT}"
+if ! test -v AWS_DEFAULT_REGION; then
+    region=$(aws configure get region)
+else
+  region=$AWS_DEFAULT_REGION
+fi
+
+#Getting Aws vpc and subnet
+vpc_id=$(aws ec2 describe-vpcs --query "Vpcs[0].[VpcId]" --output text)
+subnet_ids=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$vpc_id" --output json)
+subnet_id=$(echo "$subnet_ids" | jq -r '.Subnets[0].SubnetId')
+
+#creating atlas private endpoint
+output=$(atlas privateEndpoints aws list --projectId "${projectId}" --output json)
+private_endpoint_id=""
+# Check if the output is empty
+if [ "$(echo "$output" | jq -e '. | length == 0')" = true ]; then
+  echo "Empty"
+  # Execute the create command if the output is empty
+  create_output=$(atlas privateEndpoints aws create --region "${region}" --projectId "${projectId}" --output json)
+  private_endpoint_id=$(echo "$create_output" | jq -r '.id')
+  echo "Created endpoint with ID: $private_endpoint_id"
+
+  # Poll and wait for the status to become "AVAILABLE"
+  while true; do
+    status=$(atlas privateEndpoints aws describe "$private_endpoint_id" --projectId "$projectId" --output json | jq -r '.status')
+    if [ "$status" = "AVAILABLE" ]; then
+      echo "Status: $status"
+      break
+    fi
+    echo "Status: $status (waiting for AVAILABLE)"
+    sleep 5
+  done
+else
+  # Use jq to extract the ID of the first result
+    private_endpoint_id=$(echo "$output" | jq -r '.[0].id')
+    echo "ID: $private_endpoint_id"
+fi
+
+endpoint_service_id=$(atlas privateEndpoints aws describe "$private_endpoint_id" --projectId "$projectId" --output json | jq -r '.endpointServiceName')
+
+#creating aws private endpoint
+aws_private_endpoint_id=$(aws ec2 create-vpc-endpoint \
+  --vpc-id "$vpc_id" \
+  --service-name "$endpoint_service_id" \
+  --region "$region" \
+  --subnet-ids "$subnet_id" \
+  --vpc-endpoint-type Interface \
+  --output json | jq -r '.VpcEndpoint.VpcEndpointId')
+
 WORDTOREMOVE="template."
 cd "$(dirname "$0")" || exit
 for inputFile in inputs_*; do
 	outputFile=${inputFile//$WORDTOREMOVE/}
 	jq --arg proj "$projectId" \
-		--arg endpoint_id "$endpoint" \
+		--arg endpoint_id "$aws_private_endpoint_id" \
 		'.ProjectId?|=$proj |.EndpointId?|=$endpoint_id' \
 		"$inputFile" >"../inputs/$outputFile"
 done

--- a/cfn-resources/private-endpoint-adl/test/cfn-test-delete-inputs.sh
+++ b/cfn-resources/private-endpoint-adl/test/cfn-test-delete-inputs.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# cfn-test-delete-inputs.sh
+#
+# This tool deletes the mongodb resources used for `cfn test` as inputs.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+set -x
+
+function usage {
+  echo "usage:$0 "
+}
+
+projectId=$(jq -r '.ProjectId' ./inputs/inputs_1_create.json)
+interfaceEndpointId=$(jq -r '.EndpointId' ./inputs/inputs_1_create.json)
+
+echo "STEP 1 DELETING UNUSED AWS PRIVATE ENDPOINT"
+
+aws ec2 delete-vpc-endpoints --vpc-endpoint-ids "$interfaceEndpointId"
+
+# Delete the VPC endpoint
+echo "STEP 1 DELETING ATLAS PRIVATE ENDPOINTS"
+
+PRIVATE_ENDPOINTS=$(atlas privateEndpoints aws list --projectId "$projectId" --output json)
+# Check if there are any private endpoints
+if [[ "$PRIVATE_ENDPOINTS" == "[]" ]]; then
+  echo "No private endpoints found."
+else
+  for ATLAS_PRIVATE_ENDPOINT_SERVICE in $(echo "$PRIVATE_ENDPOINTS" | jq -r '.[].id'); do
+    # Delete the VPC endpoint
+    echo "STEP 1.a DELETING INTERFACES FOR SERVICE $ATLAS_PRIVATE_ENDPOINT_SERVICE"
+    ENDPOINT_OUTPUT=$(atlas privateEndpoints aws describe "$ATLAS_PRIVATE_ENDPOINT_SERVICE" --projectId "$projectId" --output json)
+    if ! echo "$ENDPOINT_OUTPUT" | jq -e '.interfaceEndpoints' > /dev/null; then
+      echo "No interfaceEndpoints found for $ATLAS_PRIVATE_ENDPOINT_SERVICE"
+      echo "STEP 1.d deleting privateEndpoint Service "
+      atlas privateEndpoints aws delete "$ATLAS_PRIVATE_ENDPOINT_SERVICE" --projectId "$projectId" --force
+    else
+      interfaceEndpoints=$(echo "$ENDPOINT_OUTPUT" | jq -r '.interfaceEndpoints[]')
+      for interfaceId in $(echo "$ENDPOINT_OUTPUT" | jq -r '.interfaceEndpoints[]'); do
+        echo "STEP 1.b DELETING INTERFACE $interfaceId FOR SERVICE $ATLAS_PRIVATE_ENDPOINT_SERVICE"
+        atlas privateEndpoints aws interface delete "$interfaceId" --endpointServiceId "$ATLAS_PRIVATE_ENDPOINT_SERVICE" --projectId "$projectId" --force
+
+        sleep 20 #waiting until the connection gets rejected
+        echo "STEP 1.c DELETING aws private endpoint $interfaceId FOR SERVICE $ATLAS_PRIVATE_ENDPOINT_SERVICE"
+        aws ec2 delete-vpc-endpoints --vpc-endpoint-ids "$interfaceId"
+      done
+    fi
+  done
+fi
+
+sleep 10
+
+echo "STEP 2 waiting until all private endpoints get deleted"
+while true; do
+  PRIVATE_ENDPOINTS=$(atlas privateEndpoints aws list --projectId "$projectId" --output json)
+
+  # Check if PRIVATE_ENDPOINTS is an empty array
+  if [[ "$PRIVATE_ENDPOINTS" == "[]" ]]; then
+    echo "ALL PRIVATE ENDPOINTS HAVE BEEN DELETED"
+    break
+  fi
+
+  # Optional: Add a delay before checking again (e.g., sleep for 10 seconds)
+  sleep 10
+done
+
+echo "STEP 3 deleting project"
+# delete project
+if atlas projects delete "$projectId" --force; then
+  echo "$projectId project deletion OK"
+else
+  (echo "Failed cleaning project:$projectId" && exit 1)
+fi

--- a/cfn-resources/private-endpoint-adl/test/cfn-test-delete-inputs.sh
+++ b/cfn-resources/private-endpoint-adl/test/cfn-test-delete-inputs.sh
@@ -37,7 +37,6 @@ else
       echo "STEP 1.d deleting privateEndpoint Service "
       atlas privateEndpoints aws delete "$ATLAS_PRIVATE_ENDPOINT_SERVICE" --projectId "$projectId" --force
     else
-      interfaceEndpoints=$(echo "$ENDPOINT_OUTPUT" | jq -r '.interfaceEndpoints[]')
       for interfaceId in $(echo "$ENDPOINT_OUTPUT" | jq -r '.interfaceEndpoints[]'); do
         echo "STEP 1.b DELETING INTERFACE $interfaceId FOR SERVICE $ATLAS_PRIVATE_ENDPOINT_SERVICE"
         atlas privateEndpoints aws interface delete "$interfaceId" --endpointServiceId "$ATLAS_PRIVATE_ENDPOINT_SERVICE" --projectId "$projectId" --force

--- a/cfn-resources/private-endpoint-adl/test/inputs_1_create.template.json
+++ b/cfn-resources/private-endpoint-adl/test/inputs_1_create.template.json
@@ -3,6 +3,6 @@
   "Provider": "AWS",
   "Type": "DATA_LAKE",
   "ProjectId": "<grp_id>",
-  "EndpointId": "vpce-0cd1f01dbd6a3047d",
+  "EndpointId": "",
   "Profile": "default"
 }


### PR DESCRIPTION
Fixed/Improvements deploy scripts for:

Apikeys - ApiKeysAccessLisy - there is a problem with the variables Atlas_org_id, i unified both of them
Maintenance-Widnow= profile was defined as CreateOnly, and it should be ReadOnly leadind to test failures
Datalakes: the project input variable was required for the atlas commands
Org Role Mapping: required to set an specific profile
PrivateEndpointADL: was expecting the user to provide a private endpoint, now the script is seting up the private endpoint itself

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

