### PR TITLE
fix: properly set Dynamic property in search index mappings

### DIFF
--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -188,16 +188,12 @@ func newMappings(currentModel *Model) (*admin.ApiAtlasFTSMappings, error) {
 		return nil, nil
 	}
 
-	if currentModel.Mappings.Fields != nil && currentModel.Mappings.Dynamic != nil && *currentModel.Mappings.Dynamic {
-		return nil, nil
-	}
-
 	sec, err := newMappingsFields(currentModel.Mappings.Fields)
 	if err != nil {
 		return nil, err
 	}
 	return &admin.ApiAtlasFTSMappings{
-		Dynamic: admin.PtrBool(false),
+		Dynamic: currentModel.Mappings.Dynamic,
 		Fields:  sec,
 	}, nil
 }

--- a/examples/search-index/searchIndex.json
+++ b/examples/search-index/searchIndex.json
@@ -64,7 +64,7 @@
           "Ref": "ProjectId"
         },
         "Mappings": {
-          "Dynamic": "true"
+          "Dynamic": true
         }
       }
     }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [INTMDB-1157](https://jira.mongodb.org/browse/INTMDB-1157)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments
<details>
  <summary>Locally invoking lambda</summary>
Set of properties used:

```
{
    "Profile": "default",
    "ProjectId": "64c0f3f5ce752426ab9f506b",
    "ClusterName": "cluster-name",
    "Analyzer": "lucene.standard",
    "CollectionName": "listingsAndReviews",
    "Database": "sample_airbnb",
    "Mappings": {
        "Dynamic": "true"
    },
    "Name": "with-fix",
    "SearchAnalyzer": "lucene.standard"
}
```

Following tests were run:
- creating index from master to see that dynamic config is not being set
- index with dynamic true
- index defining additional "Fields" property. As [per documentation](https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/#review-fts-index-syntax), all fields are indexed if dynamic is set to true.
- index defining only "Fields" property and omitting "Dynamic".

<img width="1327" alt="Screenshot 2023-09-29 at 12 51 00" src="https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/40ff754e-60a4-45b9-8136-228157c65239">

</details>

<details>
  <summary>Contract testing</summary>

![Screenshot 2023-09-29 at 15 00 34](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/71437899-43bb-40d9-84fc-69d46dc624f8)

</details>

<details>
  <summary>Manual testing stack using private registry</summary>

![stack](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/e7131f0e-2b32-4e18-bfce-513ebfc44bf1)

Verifying Atlas UI
![created index private extension](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/0e3ebc6e-2f42-400b-97f4-15aa1e854f59)

</details>
