### PR TITLE
refactor: Migrates LDAPVerify resource to new Atlas SDK

### DIFF
--- a/cfn-resources/ldap-verify/Makefile
+++ b/cfn-resources/ldap-verify/Makefile
@@ -1,11 +1,11 @@
-.PHONY: build test clean
+.PHONY: build debug clean
 tags=logging callback metrics scheduler
 cgo=0
 goos=linux
 goarch=amd64
 CFNREP_GIT_SHA?=$(shell git rev-parse HEAD)
 ldXflags=-s -w -X github.com/mongodb/mongodbatlas-cloudformation-resources/util.defaultLogLevel=info -X github.com/mongodb/mongodbatlas-cloudformation-resources/version.Version=${CFNREP_GIT_SHA}
-ldXflagsD=-s -w -X github.com/mongodb/mongodbatlas-cloudformation-resources/util.defaultLogLevel=debug -X github.com/mongodb/mongodbatlas-cloudformation-resources/version.Version=${CFNREP_GIT_SHA}
+ldXflagsD=-X github.com/mongodb/mongodbatlas-cloudformation-resources/util.defaultLogLevel=debug -X github.com/mongodb/mongodbatlas-cloudformation-resources/version.Version=${CFNREP_GIT_SHA}
 
 build:
 	cfn generate

--- a/cfn-resources/ldap-verify/cmd/resource/resource.go
+++ b/cfn-resources/ldap-verify/cmd/resource/resource.go
@@ -84,25 +84,23 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.ProgressEvent, error) {
 	setup()
-
 	util.SetDefaultProfileIfNotDefined(&currentModel.Profile)
 
 	if err := validateModel(ReadRequiredFields, currentModel); err != nil {
 		return *err, nil
 	}
 
-	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
-	if peErr != nil {
-		return *peErr, nil
+	client, pe := util.NewAtlasClient(&req, currentModel.Profile)
+	if pe != nil {
+		return *pe, nil
 	}
-	var res *mongodbatlas.Response
 
-	LDAPConfigResponse, res, err := client.LDAPConfigurations.GetStatus(context.Background(), *currentModel.ProjectId, *currentModel.RequestId)
+	LDAPConfigResponse, resp, err := client.AtlasV2.LDAPConfigurationApi.GetLDAPConfigurationStatus(context.Background(), *currentModel.ProjectId, *currentModel.RequestId).Execute()
 	if err != nil {
-		return progressevent.GetFailedEventByResponse(err.Error(), res.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
 
-	currentModel.CompleteByResponse(*LDAPConfigResponse)
+	currentModel.CompleteByResponse2(*LDAPConfigResponse)
 
 	return handler.ProgressEvent{
 		OperationStatus: handler.Success,


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [INTMDB-1093](https://jira.mongodb.org/browse/INTMDB-1093)

Migrating LDAPVerify resource to new Atlas SDK.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

**Contract testing:**
```
cfn test --function-name TestEntrypoint --verbose   
5 passed, 3 skipped, 16 deselected 
```

**Manual testing creating and deleting the stack using private registry:**
![cfn_create_delete](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/430982/d19e4950-5170-4f2b-80ab-a5bee09a37a5)

