### PR TITLE
refactor: Migrates X509AuthenticationDatabaseUser resource to new Atlas SDK

### DIFF
--- a/cfn-resources/x509-authentication-database-user/Makefile
+++ b/cfn-resources/x509-authentication-database-user/Makefile
@@ -1,11 +1,11 @@
-.PHONY: build test clean
+.PHONY: build debug clean
 tags=logging callback metrics scheduler
 cgo=0
 goos=linux
 goarch=amd64
 CFNREP_GIT_SHA?=$(shell git rev-parse HEAD)
 ldXflags=-s -w -X github.com/mongodb/mongodbatlas-cloudformation-resources/util.defaultLogLevel=info -X github.com/mongodb/mongodbatlas-cloudformation-resources/version.Version=${CFNREP_GIT_SHA}
-ldXflagsD=-s -w -X github.com/mongodb/mongodbatlas-cloudformation-resources/util.defaultLogLevel=debug -X github.com/mongodb/mongodbatlas-cloudformation-resources/version.Version=${CFNREP_GIT_SHA}
+ldXflagsD=-X github.com/mongodb/mongodbatlas-cloudformation-resources/util.defaultLogLevel=debug -X github.com/mongodb/mongodbatlas-cloudformation-resources/version.Version=${CFNREP_GIT_SHA}
 
 build:
 	cfn generate


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [INTMDB-1109](https://jira.mongodb.org/browse/INTMDB-1109)

Migrating X509AuthenticationDatabaseUser resource to new Atlas SDK.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

**Contract testing:**
```
cfn test --function-name TestEntrypoint --verbose   
IN PROGRESS
```

**Manual testing creating and deleting the stack using private registry:**

IN PROGRESS