### PR TITLE
fix: added insertion Order to SearchIndex

### DIFF
--- a/cfn-resources/search-index/mongodb-atlas-searchindex.json
+++ b/cfn-resources/search-index/mongodb-atlas-searchindex.json
@@ -43,6 +43,7 @@
           "items": {
             "type": "string"
           },
+          "insertionOrder" : false,
           "description": "One or more field specifications for the Atlas Search index. The element of the array must have the format fieldName:fieldType. Required if **mappings.dynamic** is omitted or set to **false**."
         }
       },


### PR DESCRIPTION
Small fix of a warning when running cfn generate

"insertionOrder" : false was added to Fields array

was set to false, because the order on this field should not be taken into consideration when updating the resource. 
(it does not matter the order of the list, just the new elements)

test were passing with this new change

![image](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/69170650/53946589-df73-4eb0-b6df-32676188d2bb)
[INTMDB-1163](https://jira.mongodb.org/browse/INTMDB-1163)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

