### PR TITLE
chore: fix so cleanup-test-env script continues if delete of one project fails

### DIFF
--- a/scripts/cleanup-test-env.sh
+++ b/scripts/cleanup-test-env.sh
@@ -36,6 +36,9 @@ echo "${projects}" | jq -c '.results[].id' | while read -r id; do
 	fi
 
 	echo "Deleting projectId ${clean_project_id}"
-	# This command will fail if the project has a cluster inside
-	atlas project delete "${clean_project_id}" --force
+	# This command can fail if project has a cluster, a private endpoint, or general failure. The echo command always succeeds so the subshell will succeed and continue
+    (
+        atlas project delete "${clean_project_id}" --force || \
+        echo "Failed to delete project with ID ${clean_project_id}"
+    )
 done


### PR DESCRIPTION
## Proposed changes

Jira ticket: [INTMDB-1123](https://jira.mongodb.org/browse/INTMDB-1123)

Maintain consistency with https://github.com/mongodb/terraform-provider-mongodbatlas/pull/1516

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

