### PR TITLE
chore: Reduce verbosity in scripts

### DIFF
--- a/cfn-resources/cfn-testing-helper.sh
+++ b/cfn-resources/cfn-testing-helper.sh
@@ -83,12 +83,11 @@ if [ -z "${2}" ]; then
 	. ./cfn-testing-helper.config
 	env | grep CFN_TEST_
 	PROJECT_NAME="${CFN_TEST_NEW_PROJECT_NAME}"
-	echo "PROJECT_NAME:${PROJECT_NAME}"
 else
 	PROJECT_NAME="${2}"
 fi
 
-echo "${PROJECT_NAME}"
+echo "PROJECT_NAME: ${PROJECT_NAME}"
 
 for res in ${resources}; do
 	[[ "${_DRY_RUN}" == "true" ]] && echo "[dry-run] would have run ./test/cfn-test-create-inputs.sh for:${resource}" && continue


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ [INTMDB-1187](https://jira.mongodb.org/browse/INTMDB-1187)

Reduce verbosity in scripts. As an example delete all "set -x" as echos statements are enough to log useful information.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code
- [X] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

