### PR TITLE
feat: AWS automation update: v54 [publish version, base url] 

### DIFF
--- a/.github/workflows/cfn-publish-resource.yaml
+++ b/.github/workflows/cfn-publish-resource.yaml
@@ -10,6 +10,10 @@ on:
         description: "the folder name of the Resource in this Repo."
         default: ""
         required: true
+      resourceVersionPublishing:
+        description: "the version used to publish the resource, empty will use the next minor version."
+        default: ""
+        required: false
       otherParams:
         description: "Resource specific environment variables used for cfn test."
         default: ""
@@ -30,6 +34,7 @@ jobs:
     env:
 
       RESOURCES: ${{ github.event.inputs.resourceNames }}
+      RESOURCE_VERSION_PUBLISHING: ${{ github.event.inputs.resourceVersionPublishing }}
       REGIONS: ${{ github.event.inputs.regions }}
       OTHER_PARAMS: ${{ github.event.inputs.otherParams }}
       TARGET_LOCATIONS_MAX_CONCURRENCY: ${{ github.event.inputs.targetLocationsMaxConcurrency }}

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -169,7 +169,7 @@ for ResourceName in "${ResourceNames[@]}"; do
   .AssumeRole[0]?|=$AssumeRole ' \
 		"$(dirname "$0")/templates/params.json" >tmp.$$.json && mv tmp.$$.json ${ParamsJsonPath}
 
-	[ -z "${RESOURCE_VERSION_PUBLISHING}" ] || jq 'del(.ResourceVersionPublishing)' ${ParamsJsonPath} >${ParamsJsonPath}
+	[ -n "${RESOURCE_VERSION_PUBLISHING}" ] || jq 'del(.ResourceVersionPublishing)' ${ParamsJsonPath} >${ParamsJsonPath}
 
 	ParamsJsonContent=$(cat ${ParamsJsonPath})
 	LocationsJsonContent=$(cat ${LocationsJsonPath})

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -15,10 +15,9 @@
 # limitations under the License.
 
 set -Eeou pipefail
-set -x
 
 # sort these by alphabetical order
-AwsSsmDocumentName="leoantoli-CFN-MongoDB-Atlas-Resource-Register"
+AwsSsmDocumentName="CFN-MongoDB-Atlas-Resource-Register"
 AssumeRole="arn:aws:iam::${AWS_ACCOUNT_ID}:role/DevOpsIntegrationsContractorsSSM"
 AccountIds="${AWS_ACCOUNT_ID}"
 DocumentVersion="\$DEFAULT"
@@ -138,8 +137,6 @@ for ResourceName in "${ResourceNames[@]}"; do
 
 	ParamsJsonPath="$(dirname "$0")"/params-temp.json
 	LocationsJsonPath="$(dirname "$0")"/locations-temp.json
-
-	jq --version
 
 	jq --arg ExecutionRoleName "${ExecutionRoleName}" \
 		--arg TargetLocationsMaxConcurrency "${TARGET_LOCATIONS_MAX_CONCURRENCY}" \

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set -Eeou pipefail
+set -x
 
 # sort these by alphabetical order
 AwsSsmDocumentName="leoantoli-CFN-MongoDB-Atlas-Resource-Register"
@@ -155,7 +156,7 @@ for ResourceName in "${ResourceNames[@]}"; do
 		--arg OtherParams "${OtherParams_string}" \
 		--arg AssumeRole "${AssumeRole}" \
 		'.ResourceName[0]?|=$ResourceName |
-  .ResourceVersionPublishing[0]?|=$ResourceVersionPublishing |
+  .ResourceVersionPublishing[0]|=$ResourceVersionPublishing |
   .OrgID[0]?|=$OrgID |
   .PubKey[0]?|=$PubKey |
   .PvtKey[0]?|=$PvtKey |

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -20,7 +20,6 @@ set -Eeou pipefail
 AwsSsmDocumentName="leoantoli-CFN-MongoDB-Atlas-Resource-Register"
 AssumeRole="arn:aws:iam::${AWS_ACCOUNT_ID}:role/DevOpsIntegrationsContractorsSSM"
 AccountIds="${AWS_ACCOUNT_ID}"
-BuilderRole="DevOpsIntegrationsContractors-CodeBuild"
 DocumentVersion="\$DEFAULT"
 DocumentRegion="us-east-1"
 ExecutionRoleName="DevOpsIntegrationsContractorsSSM"
@@ -153,7 +152,6 @@ for ResourceName in "${ResourceNames[@]}"; do
 		--arg BranchName "${BRANCH_NAME}" \
 		--arg ProjectName "${CodeBuild_Project_Name}" \
 		--arg OtherParams "${OtherParams_string}" \
-		--arg BuilderRole "${BuilderRole}" \
 		--arg AssumeRole "${AssumeRole}" \
 		'.ResourceName[0]?|=$ResourceName |
   .OrgID[0]?|=$OrgID |
@@ -162,7 +160,6 @@ for ResourceName in "${ResourceNames[@]}"; do
   .ProjectName[0]?|=$ProjectName |
   .OtherParams[0]?|=$OtherParams |
   .BranchName[0]?|=$BranchName |
-  .BuilderRole[0]?|=$BuilderRole |
   .AssumeRole[0]?|=$AssumeRole ' \
 		"$(dirname "$0")/templates/params.json" >tmp.$$.json && mv tmp.$$.json "$(dirname "$0")/params-temp.json"
 

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -24,7 +24,6 @@ BuilderRole="DevOpsIntegrationsContractors-CodeBuild"
 DocumentVersion="\$DEFAULT"
 DocumentRegion="us-east-1"
 ExecutionRoleName="DevOpsIntegrationsContractorsSSM"
-LogDeliveryBucket="atlascfnpublishing"
 Repository="https://github.com/mongodb/mongodbatlas-cloudformation-resources"
 
 # improve this code
@@ -158,7 +157,6 @@ for ResourceName in "${ResourceNames[@]}"; do
 		--arg OtherParams "${OtherParams_string}" \
 		--arg BuilderRole "${BuilderRole}" \
 		--arg AssumeRole "${AssumeRole}" \
-		--arg LogDeliveryBucket "${LogDeliveryBucket}" \
 		'.Repository[0]?|=$Repository |
   .ResourceName[0]?|=$ResourceName |
   .OrgID[0]?|=$OrgID |
@@ -168,8 +166,7 @@ for ResourceName in "${ResourceNames[@]}"; do
   .OtherParams[0]?|=$OtherParams |
   .BranchName[0]?|=$BranchName |
   .BuilderRole[0]?|=$BuilderRole |
-  .AssumeRole[0]?|=$AssumeRole |
-  .LogDeliveryBucket[0]?|=$LogDeliveryBucket ' \
+  .AssumeRole[0]?|=$AssumeRole ' \
 		"$(dirname "$0")/templates/params.json" >tmp.$$.json && mv tmp.$$.json "$(dirname "$0")/params-temp.json"
 
 	ParamsJsonContent=$(cat "$(dirname "$0")"/params-temp.json)

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -136,7 +136,6 @@ for ResourceName in "${ResourceNames[@]}"; do
 		esac
 	fi
 
-	Path="cfn-resources/${ResourceName}/"
 	CodeBuild_Project_Name="${ResourceName}-proj-$((1 + RANDOM % 1000))"
 
 	jq --arg ExecutionRoleName "${ExecutionRoleName}" \
@@ -157,7 +156,6 @@ for ResourceName in "${ResourceNames[@]}"; do
 		--arg BranchName "${BRANCH_NAME}" \
 		--arg ProjectName "${CodeBuild_Project_Name}" \
 		--arg OtherParams "${OtherParams_string}" \
-		--arg Path "${Path}" \
 		--arg BuilderRole "${BuilderRole}" \
 		--arg AssumeRole "${AssumeRole}" \
 		--arg LogDeliveryBucket "${LogDeliveryBucket}" \
@@ -169,7 +167,6 @@ for ResourceName in "${ResourceNames[@]}"; do
   .ProjectName[0]?|=$ProjectName |
   .OtherParams[0]?|=$OtherParams |
   .BranchName[0]?|=$BranchName |
-  .Path[0]?|=$Path |
   .BuilderRole[0]?|=$BuilderRole |
   .AssumeRole[0]?|=$AssumeRole |
   .LogDeliveryBucket[0]?|=$LogDeliveryBucket ' \

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -17,7 +17,7 @@
 set -Eeou pipefail
 
 # sort these by alphabetical order
-AwsSsmDocumentName="CFN-MongoDB-Atlas-Resource-Register"
+AwsSsmDocumentName="leoantoli-CFN-MongoDB-Atlas-Resource-Register"
 AssumeRole="arn:aws:iam::${AWS_ACCOUNT_ID}:role/DevOpsIntegrationsContractorsSSM"
 AccountIds="${AWS_ACCOUNT_ID}"
 BuilderRole="DevOpsIntegrationsContractors-CodeBuild"

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -24,7 +24,6 @@ BuilderRole="DevOpsIntegrationsContractors-CodeBuild"
 DocumentVersion="\$DEFAULT"
 DocumentRegion="us-east-1"
 ExecutionRoleName="DevOpsIntegrationsContractorsSSM"
-Repository="https://github.com/mongodb/mongodbatlas-cloudformation-resources"
 
 # improve this code
 if [ -z "${REGIONS+x}" ]; then
@@ -147,8 +146,7 @@ for ResourceName in "${ResourceNames[@]}"; do
     .[0].Regions?|=($Regions | gsub(" "; "") | split(",")) ' \
 		"$(dirname "$0")/templates/locations.json" >tmp.$$.json && mv tmp.$$.json "$(dirname "$0")/locations-temp.json"
 
-	jq --arg Repository "${Repository}" \
-		--arg ResourceName "${ResourceName}" \
+	jq --arg ResourceName "${ResourceName}" \
 		--arg OrgID "${ATLAS_ORG_ID}" \
 		--arg PubKey "${ATLAS_PUBLIC_KEY}" \
 		--arg PvtKey "${ATLAS_PRIVATE_KEY}" \
@@ -157,8 +155,7 @@ for ResourceName in "${ResourceNames[@]}"; do
 		--arg OtherParams "${OtherParams_string}" \
 		--arg BuilderRole "${BuilderRole}" \
 		--arg AssumeRole "${AssumeRole}" \
-		'.Repository[0]?|=$Repository |
-  .ResourceName[0]?|=$ResourceName |
+		'.ResourceName[0]?|=$ResourceName |
   .OrgID[0]?|=$OrgID |
   .PubKey[0]?|=$PubKey |
   .PvtKey[0]?|=$PvtKey |

--- a/.github/workflows/cfn-publish.sh
+++ b/.github/workflows/cfn-publish.sh
@@ -146,6 +146,7 @@ for ResourceName in "${ResourceNames[@]}"; do
 		"$(dirname "$0")/templates/locations.json" >tmp.$$.json && mv tmp.$$.json "$(dirname "$0")/locations-temp.json"
 
 	jq --arg ResourceName "${ResourceName}" \
+		--arg ResourceVersionPublishing "${RESOURCE_VERSION_PUBLISHING}" \
 		--arg OrgID "${ATLAS_ORG_ID}" \
 		--arg PubKey "${ATLAS_PUBLIC_KEY}" \
 		--arg PvtKey "${ATLAS_PRIVATE_KEY}" \
@@ -154,6 +155,7 @@ for ResourceName in "${ResourceNames[@]}"; do
 		--arg OtherParams "${OtherParams_string}" \
 		--arg AssumeRole "${AssumeRole}" \
 		'.ResourceName[0]?|=$ResourceName |
+  .ResourceVersionPublishing[0]?|=$ResourceVersionPublishing |
   .OrgID[0]?|=$OrgID |
   .PubKey[0]?|=$PubKey |
   .PvtKey[0]?|=$PvtKey |

--- a/.github/workflows/templates/params.json
+++ b/.github/workflows/templates/params.json
@@ -1,7 +1,4 @@
 {
-  "Repository": [
-    "https://github.com/mongodb/mongodbatlas-cloudformation-resources"
-  ],
   "ResourceName": [
     ""
   ],
@@ -27,6 +24,6 @@
     ""
   ],
   "AssumeRole": [
-    "arn:aws:iam::711489243244:role/DevOpsIntegrationsContractorsSSM"
+    "arn:aws:iam::accountid:role/name"
   ]
 }

--- a/.github/workflows/templates/params.json
+++ b/.github/workflows/templates/params.json
@@ -20,9 +20,6 @@
   "OtherParams": [
     "'{\"test\":\"test\"}'"
   ],
-  "BuilderRole": [
-    ""
-  ],
   "AssumeRole": [
     "arn:aws:iam::accountid:role/name"
   ]

--- a/.github/workflows/templates/params.json
+++ b/.github/workflows/templates/params.json
@@ -8,6 +8,9 @@
   "OrgID": [
     ""
   ],
+  "ResourceVersionPublishing": [
+    ""
+  ],
   "PubKey": [
     ""
   ],

--- a/.github/workflows/templates/params.json
+++ b/.github/workflows/templates/params.json
@@ -28,8 +28,5 @@
   ],
   "AssumeRole": [
     "arn:aws:iam::711489243244:role/DevOpsIntegrationsContractorsSSM"
-  ],
-  "LogDeliveryBucket": [
-    "atlascfnpublishing"
   ]
 }

--- a/.github/workflows/templates/params.json
+++ b/.github/workflows/templates/params.json
@@ -23,9 +23,6 @@
   "OtherParams": [
     "'{\"test\":\"test\"}'"
   ],
-  "Path": [
-    ""
-  ],
   "BuilderRole": [
     ""
   ],

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -44,11 +44,6 @@ parameters:
     type: String
     description: A role this document can assume
     default: ''
-  LogDeliveryBucket:
-    type: String
-    description: |-
-      The S3 bucket to which CloudFormation delivers the contract test execution logs.
-      CloudFormation delivers the logs by the time contract testing has completed and the extension has been assigned a test type status of PASSED or FAILED.
 mainSteps:
   - name: Get_Region
     action: 'aws:executeAwsApi'

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -6,20 +6,22 @@ assumeRole: '{{ AssumeRole }}'
 parameters:
   Repository:
     type: String
-    description: |-
-      https://github.com/resource
-      The URL of the resource's repository
+    description: URL of the resource repository
     default: 'https://github.com/mongodb/mongodbatlas-cloudformation-resources'
   ResourceName:
     type: String
     description: the folder name of the resource as per the folder structure in your repo.
+  ResourceVersionPublishing:
+    type: String
+    description: the version used to publish the resource, empty will use the next minor version.
+    default: null
   OtherParams:
     type: String
     default: null
     description: extra parameters that are specific to resource.
   BaseUrl:
     type: String
-    default: 'https://cloud.mongodb.com/'
+    default: https://cloud.mongodb.com/
     description: Atlas Base Url
   OrgID:
     type: String
@@ -44,7 +46,7 @@ parameters:
   AssumeRole:
     type: String
     description: A role this document can assume
-    default: ''
+    default: null
 mainSteps:
   - name: Get_Region
     action: 'aws:executeAwsApi'
@@ -100,6 +102,7 @@ mainSteps:
                 - export MCLI_PUBLIC_API_KEY=$MONGODB_ATLAS_PUBLIC_KEY
                 - export MCLI_PRIVATE_API_KEY=$MONGODB_ATLAS_PRIVATE_KEY
                 - export MCLI_OUTPUT=$MONGODB_ATLAS_OUTPUT
+                - export RESOURCE_VERSION_PUBLISHING={{ResourceVersionPublishing}}
                 - export AWS_DEFAULT_REGION={{Get_Region.RegionName}}
                 - 'git clone --branch {{ BranchName }}  {{ Repository }} provider'
                 - cd provider

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -95,6 +95,11 @@ mainSteps:
                 - export MONGODB_ATLAS_PUBLIC_KEY={{PubKey}}
                 - export MONGODB_ATLAS_PRIVATE_KEY={{PvtKey}}
                 - export MONGODB_ATLAS_OUTPUT=json
+                - export MCLI_OPS_MANAGER_URL=$MONGODB_ATLAS_BASE_URL
+                - export MCLI_ORG_ID=$MONGODB_ATLAS_ORG_ID
+                - export MCLI_PUBLIC_API_KEY=$MONGODB_ATLAS_PUBLIC_KEY
+                - export MCLI_PRIVATE_API_KEY=$MONGODB_ATLAS_PRIVATE_KEY
+                - export MCLI_OUTPUT=$MONGODB_ATLAS_OUTPUT
                 - export AWS_DEFAULT_REGION={{Get_Region.RegionName}}
                 - 'git clone --branch {{ BranchName }}  {{ Repository }} provider'
                 - cd provider

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -77,7 +77,7 @@ mainSteps:
           phases:
             install:
               runtime-versions:
-                python: 3.11.5
+                python: 3.9
                 golang: 1.20
               commands:
                 - pip install pre-commit

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -1,15 +1,6 @@
-description: |-
-  *Replace this default text with instructions or other information about your document.*  
-  ---
+description: |
   # CFN-3P-Provider-Register
   This automation document builds and registers  3rd party resource providers. This automation document can register resources in a single AWS account or in multiple accounts and regions. However, multi-account and regions require a role. Please refer to  the [SSM multi-account ](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-automation-multiple-accounts-and-regions.html) documentation.
-  ## 
-  This document builds and registers 3rd party resource providers build using the following plugins:   
-  * JAVA [link to another webpage](https://aws.amazon.com/)
-  * Go [link to another webpage](https://aws.amazon.com/)
-  * Python (Coming soon) [link to another webpage](https://aws.amazon.com/)
-  In order for CodeBuild to have the permission to build an submit the resource, a role must be created. 
-  ##
 schemaVersion: '0.3'
 assumeRole: '{{ AssumeRole }}'
 outputs:

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -41,6 +41,7 @@ parameters:
   BuilderRole:
     type: String
     description: The role that allows CodeBuild to build and submit the resource on your behalf
+    default: DevOpsIntegrationsContractors-CodeBuild
   AssumeRole:
     type: String
     description: A role this document can assume

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -65,7 +65,7 @@ mainSteps:
       description: This environment builds a 3P resource
       environment:
         computeType: BUILD_GENERAL1_SMALL
-        image: 'aws/codebuild/amazonlinux2-x86_64-standard:4.0'
+        image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0'
         type: LINUX_CONTAINER
         privilegedMode: true
       name: '{{ProjectName}}'
@@ -77,7 +77,7 @@ mainSteps:
           phases:
             install:
               runtime-versions:
-                python: 3.9
+                python: 3.11
                 golang: 1.20
               commands:
                 - pip install pre-commit

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -12,7 +12,6 @@ parameters:
     default: 'https://github.com/mongodb/mongodbatlas-cloudformation-resources'
   ResourceName:
     type: String
-    default: null
     description: the folder name of the resource as per the folder structure in your repo.
   ProjectName:
     type: String
@@ -21,15 +20,15 @@ parameters:
   OrgID:
     type: String
     default: null
-    description: ATLAS OrgID.
+    description: Atlas OrgID
   PubKey:
     type: String
     default: null
-    description: ATLAS Public key.
+    description: Atlas Public key
   PvtKey:
     type: String
     default: null
-    description: ATLAS Private key.
+    description: Atlas Private key
   BranchName:
     type: String
     default: null
@@ -46,6 +45,10 @@ parameters:
     type: String
     description: A role this document can assume
     default: ''
+  BaseUrl:
+    type: String
+    default: 'https://cloud.mongodb.com/'
+    description: Atlas Base Url
 mainSteps:
   - name: Get_Region
     action: 'aws:executeAwsApi'
@@ -91,12 +94,13 @@ mainSteps:
                 - unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
                 - ./sam-installation/install
                 - pip3 install cloudformation-cli cloudformation-cli-go-plugin
-                - export ATLAS_ORG_ID={{OrgID}}
-                - export ATLAS_PUBLIC_KEY={{PubKey}}
-                - export ATLAS_PRIVATE_KEY={{PvtKey}}
-                - export MCLI_PUBLIC_API_KEY=$ATLAS_PUBLIC_KEY
-                - export MCLI_PRIVATE_API_KEY=$ATLAS_PRIVATE_KEY
-                - export MCLI_ORG_ID=$ATLAS_ORG_ID
+                - export MONGODB_ATLAS_BASE_URL={{BaseUrl}}
+                - export MONGODB_ATLAS_ORG_ID={{OrgID}}
+                - export MONGODB_ATLAS_PUBLIC_KEY={{PubKey}}
+                - export MONGODB_ATLAS_PRIVATE_KEY={{PvtKey}}
+                - export MCLI_PUBLIC_API_KEY=$MONGODB_ATLAS_PUBLIC_KEY
+                - export MCLI_PRIVATE_API_KEY=$MONGODB_ATLAS_PRIVATE_KEY
+                - export MCLI_ORG_ID=$MONGODB_ATLAS_ORG_ID
                 - export MCLI_OUTPUT=json
                 - export AWS_DEFAULT_REGION={{Get_Region.RegionName}}
                 - 'git clone --branch {{ BranchName }}  {{ Repository }} provider'

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -77,8 +77,8 @@ mainSteps:
           phases:
             install:
               runtime-versions:
-                python: 3.9
-                golang: 1.18
+                python: 3.11.5
+                golang: 1.20
               commands:
                 - pip install pre-commit
                 - yum update -y

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -13,15 +13,15 @@ parameters:
     description: the folder name of the resource as per the folder structure in your repo.
   ResourceVersionPublishing:
     type: String
-    description: the version used to publish the resource, empty will use the next minor version.
-    default: null
+    description: 'the version used to publish the resource, empty will use the next minor version.'
+    default: ''
   OtherParams:
     type: String
-    default: null
+    default: ''
     description: extra parameters that are specific to resource.
   BaseUrl:
     type: String
-    default: https://cloud.mongodb.com/
+    default: 'https://cloud.mongodb.com/'
     description: Atlas Base Url
   OrgID:
     type: String

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -9,6 +9,7 @@ parameters:
     description: |-
       https://github.com/resource
       The URL of the resource's repository
+    default: 'https://github.com/mongodb/mongodbatlas-cloudformation-resources'
   ResourceName:
     type: String
     default: null

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -13,30 +13,30 @@ parameters:
   ResourceName:
     type: String
     description: the folder name of the resource as per the folder structure in your repo.
-  ProjectName:
-    type: String
-    default: null
-    description: the name of the Build Project created in CodeBuild when automation is run.
-  OrgID:
-    type: String
-    default: null
-    description: Atlas OrgID
-  PubKey:
-    type: String
-    default: null
-    description: Atlas Public key
-  PvtKey:
-    type: String
-    default: null
-    description: Atlas Private key
-  BranchName:
-    type: String
-    default: null
-    description: git branch name.
   OtherParams:
     type: String
     default: null
     description: extra parameters that are specific to resource.
+  BaseUrl:
+    type: String
+    default: 'https://cloud.mongodb.com/'
+    description: Atlas Base Url
+  OrgID:
+    type: String
+    description: Atlas OrgID
+  PubKey:
+    type: String
+    description: Atlas Public key
+  PvtKey:
+    type: String
+    description: Atlas Private key
+  BranchName:
+    type: String
+    default: master
+    description: git branch name.
+  ProjectName:
+    type: String
+    description: the name of the Build Project created in CodeBuild when automation is run.
   BuilderRole:
     type: String
     description: The role that allows CodeBuild to build and submit the resource on your behalf
@@ -45,10 +45,6 @@ parameters:
     type: String
     description: A role this document can assume
     default: ''
-  BaseUrl:
-    type: String
-    default: 'https://cloud.mongodb.com/'
-    description: Atlas Base Url
 mainSteps:
   - name: Get_Region
     action: 'aws:executeAwsApi'
@@ -98,10 +94,7 @@ mainSteps:
                 - export MONGODB_ATLAS_ORG_ID={{OrgID}}
                 - export MONGODB_ATLAS_PUBLIC_KEY={{PubKey}}
                 - export MONGODB_ATLAS_PRIVATE_KEY={{PvtKey}}
-                - export MCLI_PUBLIC_API_KEY=$MONGODB_ATLAS_PUBLIC_KEY
-                - export MCLI_PRIVATE_API_KEY=$MONGODB_ATLAS_PRIVATE_KEY
-                - export MCLI_ORG_ID=$MONGODB_ATLAS_ORG_ID
-                - export MCLI_OUTPUT=json
+                - export MONGODB_ATLAS_OUTPUT=json
                 - export AWS_DEFAULT_REGION={{Get_Region.RegionName}}
                 - 'git clone --branch {{ BranchName }}  {{ Repository }} provider'
                 - cd provider

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -48,12 +48,6 @@ parameters:
     type: String
     default: null
     description: extra parameters that are specific to resource.
-  Path:
-    type: String
-    default: null
-    description: |-
-      provider/
-      The path of the resource in the repository. Example: https://github.com/resource/provider The path to the resource is provider/. If the repository only contains a single resource, the default value of root will look for the resource in the root of the repository.
   BuilderRole:
     type: String
     description: The role that allows CodeBuild to build and submit the resource on your behalf
@@ -76,88 +70,6 @@ mainSteps:
       - Name: RegionName
         Selector: '$.AvailabilityZones[0].RegionName'
         Type: String
-  - name: Select_Language
-    action: 'aws:executeScript'
-    inputs:
-      Runtime: python3.6
-      Handler: script_handler
-      Script: |-
-        import urllib
-        import json
-        def get_config(url,path,branchname):
-            """
-            Determines the runtime.
-            :param url: A URL
-            :param path: The path to the build directory
-            """
-            try:
-              if path == "root":
-                print('{url}/raw/{branchname}/.rpdk-config'.format(url=url,branchname=branchname))
-                location = '{url}/raw/{branchname}/.rpdk-config'.format(url=url,branchname=branchname)
-              else:
-                print('{url}/raw/{branchname}/{path}.rpdk-config'.format(url=url, path=path,branchname=branchname))
-                location = '{url}/raw/{branchname}/{path}.rpdk-config'.format(url=url, path=path,branchname=branchname)
-              req = urllib.request.Request(location)
-              ##parsing response
-              r = urllib.request.urlopen(req).read()
-              config = json.loads(r.decode('utf-8'))
-              return config
-            except: 
-              print('Resource configuration not found')
-              raise Exception('Resource configuration not found')
-        def is_live(url):
-            """
-            Checks that a given URL is reachable.
-            :param url: A URL
-            """
-            request = urllib.request.Request(url)
-            request.get_method = lambda: 'HEAD'
-            try:
-                urllib.request.urlopen(request)
-            except urllib.request.HTTPError:
-                print('Repository not found')
-                raise Exception('Repository not found')
-
-
-
-        def script_handler(events, context):
-          is_live(events['url'])
-          print(events['branchname'])
-          print('{url}/raw/{branchname}/{path}.rpdk-config'.format(url=events['url'], path=events['path'],branchname=events['branchname']))
-          config = get_config(url=events['url'], path=events['path'],branchname=events['branchname'])
-          runtime = config['language']
-          typename = config['typeName']
-          if events['path'] == "root":
-            return {'typename': typename, 'runtime': runtime, 'path': '.'}
-          else:
-            return {'typename': typename, 'runtime': runtime, 'path': events['path']}
-      InputPayload:
-        url: '{{ Repository }}'
-        path: '{{ Path }}'
-        branchname: '{{ BranchName }}'
-    outputs:
-      - Selector: $.Payload.runtime
-        Type: String
-        Name: runtime
-      - Name: path
-        Selector: $.Payload.path
-        Type: String
-      - Name: resourcename
-        Selector: $.Payload.resourcename
-        Type: String
-      - Name: typename
-        Selector: $.Payload.typename
-        Type: String
-    description: The step reads the .rpdk file and determines what build environment to use.
-  - name: Build_Branch
-    action: 'aws:branch'
-    inputs:
-      Choices:
-        - NextStep: Go_Build_Enviroment
-          Variable: '{{Select_Language.runtime}}'
-          StringEquals: go
-    description: Creates an environment that deploys a 3rd party resource
-    nextStep: Start_Build
   - name: Go_Build_Enviroment
     action: 'aws:executeAwsApi'
     inputs:

--- a/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -3,8 +3,6 @@ description: |
   This automation document builds and registers  3rd party resource providers. This automation document can register resources in a single AWS account or in multiple accounts and regions. However, multi-account and regions require a role. Please refer to  the [SSM multi-account ](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-automation-multiple-accounts-and-regions.html) documentation.
 schemaVersion: '0.3'
 assumeRole: '{{ AssumeRole }}'
-outputs:
-  - Default_Version.ARN
 parameters:
   Repository:
     type: String
@@ -156,14 +154,3 @@ mainSteps:
       Service: codebuild
       Api: delete-project
       name: '{{ProjectName}}'
-  - name: Default_Version
-    action: 'aws:executeAwsApi'
-    inputs:
-      Service: cloudformation
-      Api: DescribeType
-      Type: RESOURCE
-      TypeName: '{{ Select_Language.typename }}'
-    outputs:
-      - Name: ARN
-        Selector: $.Arn
-        Type: String


### PR DESCRIPTION
## Proposed changes

Change publishing AWS SSM Doc:

- Support a specific publishing version, support base_url. Change AWS SSM doc to receive and give the publishing version variable  PUBLISHING_RESOURCE_VERSION.
- Update from Go 1.18 to 1.20
- Support base_url
- Add default values
- Simplify SSM doc

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation (if appropriate)
- [X] I have run `make fmt` and formatted my code
- [X] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

Publishing ldap-verify resource type continues working fine
