### PR TITLE
fix: ensure publish process fails if initial submission to private registry fails

### DIFF
--- a/cfn-resources/cfn-submit-helper.sh
+++ b/cfn-resources/cfn-submit-helper.sh
@@ -62,6 +62,7 @@ for resource in ${resources}; do
 	cd "${resource}"
 	echo "resource: ${resource}"
 	echo "Submitting to CloudFormation with flags: ${CFN_SUBMIT_CFN_FLAGS}"
-	cfn submit "${CFN_SUBMIT_CFN_FLAGS}" || true
+	# ensure error is thrown if registration to private registry fails
+	cfn submit "${CFN_SUBMIT_CFN_FLAGS}"
 	cd -
 done


### PR DESCRIPTION
## Proposed changes

Jira ticket with context: https://jira.mongodb.org/browse/INTMDB-1207

Before this fix, if there was a failure when submitting to the private registry the release process continues and uses the last version present in the private registry. Fortunately, the publishing was failing later on due to a missing execution role.
![without fix](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/35aa2e36-ba89-4a66-a7a3-bfb562c02aa9)

After the fix, if submission to the private registry fails the release process is stopped giving direct insight on the problem and ensuring no incorrect publish is made:
![with-fix](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/b4eedf8b-1b7f-4834-bab8-3bba2f64b79d)


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

