### PR TITLE
fix!: INTMDB-1175 fixed cloud Backup snapshot primary identifier

### DIFF
--- a/cfn-resources/cloud-backup-snapshot/cmd/resource/model.go
+++ b/cfn-resources/cloud-backup-snapshot/cmd/resource/model.go
@@ -6,7 +6,7 @@ package resource
 type Model struct {
 	Profile          *string                                              `json:",omitempty"`
 	CloudProvider    *string                                              `json:",omitempty"`
-	ClusterName      *string                                              `json:",omitempty"`
+	InstanceType     *string                                              `json:",omitempty"`
 	InstanceName     *string                                              `json:",omitempty"`
 	CreatedAt        *string                                              `json:",omitempty"`
 	Description      *string                                              `json:",omitempty"`

--- a/cfn-resources/cloud-backup-snapshot/docs/README.md
+++ b/cfn-resources/cloud-backup-snapshot/docs/README.md
@@ -13,7 +13,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Type" : "MongoDB::Atlas::CloudBackupSnapshot",
     "Properties" : {
         "<a href="#profile" title="Profile">Profile</a>" : <i>String</i>,
-        "<a href="#clustername" title="ClusterName">ClusterName</a>" : <i>String</i>,
+        "<a href="#instancetype" title="InstanceType">InstanceType</a>" : <i>String</i>,
         "<a href="#instancename" title="InstanceName">InstanceName</a>" : <i>String</i>,
         "<a href="#description" title="Description">Description</a>" : <i>String</i>,
         "<a href="#frequencytype" title="FrequencyType">FrequencyType</a>" : <i>String</i>,
@@ -37,7 +37,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Type: MongoDB::Atlas::CloudBackupSnapshot
 Properties:
     <a href="#profile" title="Profile">Profile</a>: <i>String</i>
-    <a href="#clustername" title="ClusterName">ClusterName</a>: <i>String</i>
+    <a href="#instancetype" title="InstanceType">InstanceType</a>: <i>String</i>
     <a href="#instancename" title="InstanceName">InstanceName</a>: <i>String</i>
     <a href="#description" title="Description">Description</a>: <i>String</i>
     <a href="#frequencytype" title="FrequencyType">FrequencyType</a>: <i>String</i>
@@ -68,35 +68,27 @@ _Type_: String
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
-#### ClusterName
+#### InstanceType
 
-Human-readable label that identifies the cluster.
+Type of instance specified on the Instance Name serverless or cluster
 
 _Required_: Yes
 
 _Type_: String
 
-_Minimum Length_: <code>1</code>
-
-_Maximum Length_: <code>64</code>
+_Allowed Values_: <code>serverless</code> | <code>cluster</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### InstanceName
 
-Human-readable label that identifies the serverless instance.
+The instance name of the Serverless/Cluster whose snapshot you want to restore or you want to retrieve restore snapshot.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
-_Minimum Length_: <code>1</code>
-
-_Maximum Length_: <code>64</code>
-
-_Pattern_: <code>^([a-zA-Z0-9]([a-zA-Z0-9-]){0,21}(?<!-)([\w]{0,42}))$</code>
-
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### Description
 

--- a/cfn-resources/cloud-backup-snapshot/mongodb-atlas-cloudbackupsnapshot.json
+++ b/cfn-resources/cloud-backup-snapshot/mongodb-atlas-cloudbackupsnapshot.json
@@ -255,18 +255,17 @@
         "GCP"
       ]
     },
-    "ClusterName": {
+    "InstanceType": {
+      "description": "Type of instance specified on the Instance Name serverless or cluster",
       "type": "string",
-      "description": "Human-readable label that identifies the cluster.",
-      "maxLength": 64,
-      "minLength": 1
+      "enum": [
+        "serverless",
+        "cluster"
+      ]
     },
     "InstanceName": {
-      "type": "string",
-      "description": "Human-readable label that identifies the serverless instance.",
-      "maxLength": 64,
-      "minLength": 1,
-      "pattern": "^([a-zA-Z0-9]([a-zA-Z0-9-]){0,21}(?<!-)([\\w]{0,42}))$"
+      "description": "The instance name of the Serverless/Cluster whose snapshot you want to restore or you want to retrieve restore snapshot.",
+      "type": "string"
     },
     "CreatedAt": {
       "type": "string",
@@ -449,16 +448,19 @@
   ],
   "createOnlyProperties": [
     "/properties/ProjectId",
-    "/properties/ClusterName",
+    "/properties/InstanceName",
+    "/properties/InstanceType",
     "/properties/Profile"
   ],
   "required": [
     "ProjectId",
-    "ClusterName"
+    "InstanceName",
+    "InstanceType"
   ],
   "primaryIdentifier": [
     "/properties/ProjectId",
-    "/properties/ClusterName",
+    "/properties/InstanceName",
+    "/properties/InstanceType",
     "/properties/SnapshotId",
     "/properties/Profile"
   ],

--- a/cfn-resources/cloud-backup-snapshot/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/cloud-backup-snapshot/test/cfn-test-create-inputs.sh
@@ -51,7 +51,7 @@ rm -rf inputs
 mkdir inputs
 jq --arg group_id "$projectId" \
 	--arg clusterName "$clusterName" \
-	'.ClusterName?|=$clusterName |.ProjectId?|=$group_id' \
+	'.InstanceName?|=$clusterName |.ProjectId?|=$group_id' \
 	"$(dirname "$0")/inputs_1_create.template.json" >"inputs/inputs_1_create.json"
 
 ls -l inputs

--- a/cfn-resources/cloud-backup-snapshot/test/cfn-test-delete-inputs.sh
+++ b/cfn-resources/cloud-backup-snapshot/test/cfn-test-delete-inputs.sh
@@ -13,7 +13,7 @@ function usage {
 }
 
 projectId=$(jq -r '.ProjectId' ./inputs/inputs_1_create.json)
-clusterName=$(jq -r '.ClusterName' ./inputs/inputs_1_create.json)
+clusterName=$(jq -r '.InstanceName' ./inputs/inputs_1_create.json)
 
 #delete Cluster
 if atlas clusters delete "$clusterName" --projectId "${projectId}" --force; then

--- a/cfn-resources/cloud-backup-snapshot/test/inputs_1_create.template.json
+++ b/cfn-resources/cloud-backup-snapshot/test/inputs_1_create.template.json
@@ -1,6 +1,7 @@
 {
   "ProjectId": "",
-  "ClusterName": "",
+  "InstanceType": "cluster",
+  "InstanceName": "",
   "Description": "snapshotA through cloud formation template",
   "RetentionInDays": "5",
   "Profile": "default"

--- a/examples/cloud-backup-snapshot/snapshot.json
+++ b/examples/cloud-backup-snapshot/snapshot.json
@@ -7,10 +7,15 @@
       "Description": "",
       "ConstraintDescription": ""
     },
-    "ClusterName": {
+    "InstanceName": {
       "Type": "String",
-      "Description": "",
+      "Description": "Atlas Cluster Name where to get the snapshot",
       "ConstraintDescription": ""
+    },
+    "InstanceType" : {
+      "Type" : "String",
+      "Default" : "cluster",
+      "AllowedValues" : ["cluster", "serverless"]
     },
     "Profile": {
       "Type": "String",
@@ -27,8 +32,11 @@
         "ProjectId": {
           "Ref": "ProjectId"
         },
-        "ClusterName": {
-          "Ref": "ClusterName"
+        "InstanceName": {
+          "Ref": "InstanceName"
+        },
+        "InstanceType": {
+          "Ref": "InstanceType"
         },
         "Description": "A testing for creating cloud provider snapshots",
         "RetentionInDays": 3,


### PR DESCRIPTION
## Proposed changes

The original configuration of the Cloud Backup Snapshot resource included properties for ClusterName and InstanceName. However, this setup led to errors during read operations, as only ClusterName served as a primary identifier. When InstanceName was specified instead of ClusterName, it resulted in primary identifier errors.

To rectify this, the following modifications have been implemented:

Removal of ClusterName:
The ClusterName property, which posed challenges due to its exclusive primary identifier status, has been removed from the configuration. This change eliminates the confusion arising from the presence of both ClusterName and InstanceName.

InstanceName as Primary Identifier:
The InstanceName property now takes center stage as the primary identifier for the Cloud Backup Snapshot. This ensures a clear and unambiguous identification process when creating and managing schedules.

Introduction of InstanceType:
A new field named InstanceType has been introduced to the resource configuration. This field allows users to specify the type of instance for which the Cloud Backup Snapshot is being created. It can take two distinct values: "cluster" or "serverless."

### Test:
Since there is no functionality to CREATE a cloud backup snapshot, the only way the user can use this resource will be importing a snapshot using the "Import resource into current stack"

for this ive defined a schema with 1 normal snapshot, and then ive modified it to import the existing serverless:

``` json
"CloudBackupSnapshotServerless": {
      "Type": "MongoDB::Atlas::CloudBackupSnapshot",
      "DeletionPolicy" : "Retain",
      "Properties": {
        "ProjectId": {
          "Ref": "ProjectId"
        },
        "InstanceName": "ServerlessInstance0",
        "InstanceType": "serverless",
        "Profile": {
          "Ref": "Profile"
        }
      }
    }
```

<img width="991" alt="image" src="https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/69170650/cc1f97da-bfd3-4b76-9971-cc9967f123a0">


_Jira ticket: [INTMDB-1175](https://jira.mongodb.org/browse/INTMDB-1175)


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

