### PR TITLE
refactor: remove usages of old sdk in e2e tests and resources where usage was unintentionally left

### DIFF
--- a/cfn-resources/alert-configuration/cmd/resource/resource.go
+++ b/cfn-resources/alert-configuration/cmd/resource/resource.go
@@ -21,8 +21,6 @@ import (
 	"reflect"
 	"strings"
 
-	"go.mongodb.org/atlas/mongodbatlas"
-
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -200,8 +198,8 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	// Cannot enable/disable ONLY via update (if only send enable as changed field server returns a 500 error)
 	// so have to use different method to change enabled.
-	if reflect.DeepEqual(alertReq, &mongodbatlas.AlertConfiguration{Enabled: aws.Bool(true)}) ||
-		reflect.DeepEqual(alertReq, &mongodbatlas.AlertConfiguration{Enabled: aws.Bool(false)}) {
+	if reflect.DeepEqual(alertReq, &atlasSDK.GroupAlertsConfig{Enabled: aws.Bool(true)}) ||
+		reflect.DeepEqual(alertReq, &atlasSDK.GroupAlertsConfig{Enabled: aws.Bool(false)}) {
 		alertModel, res, err = atlasV2.AlertConfigurationsApi.ToggleAlertConfiguration(context.Background(), projectID, id, &atlasSDK.AlertsToggle{Enabled: alertReq.Enabled}).Execute()
 	} else {
 		alertModel, res, err = atlasV2.AlertConfigurationsApi.UpdateAlertConfiguration(context.Background(), projectID, id, alertReq).Execute()

--- a/cfn-resources/org-invitation/cmd/resource/resource.go
+++ b/cfn-resources/org-invitation/cmd/resource/resource.go
@@ -171,14 +171,15 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *modelValidation, nil
 	}
 
-	client, peErr := util.NewMongoDBClient(req, currentModel.Profile)
+	client, peErr := util.NewAtlasClient(&req, currentModel.Profile)
+	atlasV2 := client.AtlasV2
 	if peErr != nil {
 		return *peErr, nil
 	}
 
-	res, err := client.Organizations.DeleteInvitation(context.Background(), *currentModel.OrgId, *currentModel.Id)
+	_, res, err := atlasV2.OrganizationsApi.DeleteOrganizationInvitation(context.Background(), *currentModel.OrgId, *currentModel.Id).Execute()
 	if err != nil {
-		return progressevent.GetFailedEventByResponse(err.Error(), res.Response), nil
+		return progressevent.GetFailedEventByResponse(err.Error(), res), nil
 	}
 	_, _ = log.Debugf("deleted invitation with Id :%s", *currentModel.Id)
 

--- a/cfn-resources/project-invitation/cmd/resource/resource.go
+++ b/cfn-resources/project-invitation/cmd/resource/resource.go
@@ -39,12 +39,12 @@ func setup() {
 }
 
 func validateProjectInvitationAlreadyAccepted(ctx context.Context, client *util.MongoDBClient, username, projectID string) (bool, error) {
-	user, _, err := client.Atlas.AtlasUsers.GetByName(ctx, username)
+	user, _, err := client.AtlasV2.MongoDBCloudUsersApi.GetUserByUsername(ctx, username).Execute()
 	if err != nil {
 		return false, err
 	}
 	for _, role := range user.Roles {
-		if role.GroupID == projectID {
+		if util.AreStringPtrEqual(role.GroupId, &projectID) {
 			return true, nil
 		}
 	}

--- a/cfn-resources/test/e2e/utility/util.go
+++ b/cfn-resources/test/e2e/utility/util.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	cfn "github.com/aws/aws-sdk-go-v2/service/cloudformation"
-	"go.mongodb.org/atlas/mongodbatlas"
+	"go.mongodb.org/atlas-sdk/v20231001001/admin"
 )
 
 func GetRandNum() *big.Int {
@@ -79,7 +79,7 @@ func runShScript(t *testing.T, path string) ([]byte, error) {
 	return resp, err
 }
 
-func NewClients(t *testing.T) (cfnClient *cfn.Client, atlasClient *mongodbatlas.Client) {
+func NewClients(t *testing.T) (cfnClient *cfn.Client, atlasClient *admin.APIClient) {
 	t.Helper()
 
 	t.Log("Setting clients")

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -212,7 +212,7 @@ func NewAtlasClient(req *handler.Request, profileName *string) (*MongoDBClient, 
 
 	c := Config{BaseURL: prof.BaseURL}
 	// New SDK Client
-	sdkV2Client, err := c.newSDKV2Client(client)
+	sdkV2Client, err := c.NewSDKV2Client(client)
 	if err != nil {
 		return nil, &handler.ProgressEvent{
 			OperationStatus:  handler.Failed,
@@ -254,7 +254,7 @@ func NewAtlasV2OnlyClient(req *handler.Request, profileName *string, profileName
 
 	c := Config{BaseURL: prof.BaseURL}
 	// New SDK Client
-	sdkV2Client, err := c.newSDKV2Client(client)
+	sdkV2Client, err := c.NewSDKV2Client(client)
 	if err != nil {
 		return nil, &handler.ProgressEvent{
 			OperationStatus:  handler.Failed,
@@ -270,7 +270,7 @@ func NewAtlasV2OnlyClient(req *handler.Request, profileName *string, profileName
 	return clients, nil
 }
 
-func (c *Config) newSDKV2Client(client *http.Client) (*atlasSDK.APIClient, error) {
+func (c *Config) NewSDKV2Client(client *http.Client) (*atlasSDK.APIClient, error) {
 	opts := []atlasSDK.ClientModifier{
 		atlasSDK.UseHTTPClient(client),
 		atlasSDK.UseUserAgent(userAgent),

--- a/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
+++ b/cfn-resources/x509-authentication-database-user/cmd/resource/resource.go
@@ -17,7 +17,6 @@ package resource
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go/aws"
@@ -27,7 +26,6 @@ import (
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	"go.mongodb.org/atlas-sdk/v20231001001/admin"
-	"go.mongodb.org/atlas/mongodbatlas"
 )
 
 var CreateRequiredFields = []string{constants.ProjectID, constants.UserID}
@@ -179,18 +177,4 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 func isEnabled(certificate *admin.UserSecurity) bool {
 	return certificate != nil && certificate.CustomerX509 != nil && util.IsStringPresent(certificate.CustomerX509.Cas)
-}
-
-func ReadUserX509Certificate(client *mongodbatlas.Client, currentModel *Model) (*Model, error) {
-	projectID := *currentModel.ProjectId
-
-	certificate, _, err := client.X509AuthDBUsers.GetCurrentX509Conf(context.Background(), projectID)
-	if err != nil {
-		return nil, fmt.Errorf("error reading MongoDB X509 Authentication for DB Users(%s) in the project(%s): %s", *currentModel.UserName, projectID, err)
-	} else if certificate != nil {
-		currentModel.CustomerX509 = &CustomerX509{
-			Cas: &certificate.Cas,
-		}
-	}
-	return currentModel, nil
 }


### PR DESCRIPTION
## Proposed changes
_Jira ticket:_ [INTMDB-1243](https://jira.mongodb.org/browse/INTMDB-1243)

This PR includes the following changes to remove left over usages of old sdk, with the end goal of removing the old sdk dependency from the project:

- migrate all usages of old sdk in e2e tests utilities
- remove unused code in `cfn-resources/x509-authentication-database-user`
- fix code in alert-configuration that was using old sdk struct for a comparison operation.
- refactor delete operation in `org-invitation` which was not migrated.
- refactor get operation in `project-invitation` which was not migrated.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

<details>
  <summary>Running e2e locally to verify all operations work well</summary>

```
util.go:62: E2E test resource type MongoDB::Atlas::Project6820 successfully de-registered from private registry!
--- PASS: TestProjectCFN (143.17s)
    --- PASS: TestProjectCFN/Validate_Template (0.36s)
    --- PASS: TestProjectCFN/Create_Stack (13.50s)
    --- PASS: TestProjectCFN/Update_Stack (15.62s)
    --- PASS: TestProjectCFN/Delete_Stack (7.07s)
PASS
ok      command-line-arguments  143.567s
```

</details>

<details>
  <summary>Testing update of alert configuration enabled field</summary>

For this case I verified if current published version 2.0.0 and the new changes had issues when updating enabled field, update was successful in both cases.

</details>
