### PR TITLE
fix: INTMDB-1227 Cloud Backup Restore Job added required props

### DIFF
--- a/cfn-resources/cloud-backup-restore-jobs/docs/README.md
+++ b/cfn-resources/cloud-backup-restore-jobs/docs/README.md
@@ -65,7 +65,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 Type of instance specified on the Instance Name serverless or cluster
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -77,7 +77,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 The instance name of the Serverless/Cluster whose snapshot you want to restore or you want to retrieve restore jobs.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -87,7 +87,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 Type of restore job to create.The value can be any one of download,automated or point_in_time 
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -99,7 +99,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 Unique identifier of the source snapshot ID of the restore job.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 

--- a/cfn-resources/cloud-backup-restore-jobs/mongodb-atlas-cloudbackuprestorejobs.json
+++ b/cfn-resources/cloud-backup-restore-jobs/mongodb-atlas-cloudbackuprestorejobs.json
@@ -141,7 +141,11 @@
   },
   "additionalProperties": false,
   "required": [
-    "ProjectId"
+    "ProjectId",
+    "InstanceName",
+    "InstanceType",
+    "SnapshotId",
+    "DeliveryType"
   ],
   "createOnlyProperties": [
     "/properties/ProjectId",


### PR DESCRIPTION
## Proposed changes

Some properties were missing on the Required fields tag on the Cloud Backup Restore Job resource:
    "InstanceName",
    "InstanceType",
    "SnapshotId",
    "DeliveryType"

where added to the the required section

_Jira ticket:_ [INTMDB-1227](https://jira.mongodb.org/browse/INTMDB-1227)

Link to any related issue(s): 

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

