### PR TITLE
fix: project name update is fixed

### DIFF
--- a/cfn-resources/project/docs/README.md
+++ b/cfn-resources/project/docs/README.md
@@ -51,7 +51,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
 #### OrgId
 

--- a/cfn-resources/project/mongodb-atlas-project.json
+++ b/cfn-resources/project/mongodb-atlas-project.json
@@ -147,7 +147,6 @@
     "OrgId"
   ],
   "createOnlyProperties": [
-    "/properties/Name",
     "/properties/Profile"
   ],
   "writeOnlyProperties": [

--- a/cfn-resources/project/resource-role.yaml
+++ b/cfn-resources/project/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/MongoDB-Atlas-Project/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy
@@ -23,28 +30,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                - "secretsmanager:CreateSecret"
-                - "secretsmanager:CreateSecretInput"
-                - "secretsmanager:DescribeSecret"
                 - "secretsmanager:GetSecretValue"
-                - "secretsmanager:PutSecretValue"
-                - "secretsmanager:UpdateSecretVersionStage"
-                - "ec2:CreateVpcEndpoint"
-                - "ec2:DeleteVpcEndpoints"
-                - "cloudformation:CreateResource"
-                - "cloudformation:DeleteResource"
-                - "cloudformation:GetResource"
-                - "cloudformation:GetResourceRequestStatus"
-                - "cloudformation:ListResources"
-                - "cloudformation:UpdateResource"
-                - "iam:AttachRolePolicy"
-                - "iam:CreateRole"
-                - "iam:DeleteRole"
-                - "iam:GetRole"
-                - "iam:GetRolePolicy"
-                - "iam:ListAttachedRolePolicies"
-                - "iam:ListRolePolicies"
-                - "iam:PutRolePolicy"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/cfn-resources/project/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/project/test/cfn-test-create-inputs.sh
@@ -55,7 +55,7 @@ jq --arg org "$MONGODB_ATLAS_ORG_ID" \
 	"$(dirname "$0")/inputs_1_create.template.json" >"inputs/inputs_1_create.json"
 
 jq --arg org "$MONGODB_ATLAS_ORG_ID" \
-	--arg name "${name}" \
+	--arg name "${name}-update" \
 	--arg key_id "$api_key_id" \
 	--arg team_id "$team_id" \
 	'.OrgId?|=$org | .Name?|=$name | .ProjectApiKeys[0].Key?|=$key_id | .ProjectTeams[0].TeamId?|=$team_id' \

--- a/cfn-resources/project/test/contract-testing/cfn-test-create-inputs.sh
+++ b/cfn-resources/project/test/contract-testing/cfn-test-create-inputs.sh
@@ -49,7 +49,7 @@ jq --arg org "${org_id}" \
 	"test/inputs_1_create.template.json" >"inputs/inputs_1_create.json"
 
 jq --arg org "${org_id}" \
-	--arg name "${project_name}" \
+	--arg name "${project_name}-update" \
 	--arg profile "${profile}" \
 	--arg key_id "$api_key_id" \
 	--arg team_id "$team_id" \


### PR DESCRIPTION
fix: Project schema change to fix the name update issue.

JIRA Ticket: https://jira.mongodb.org/browse/INTMDB-1203

Changes:
Removed name from createOnly property


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [x] This change requires a documentation update

## Manual QA performed:

- [x] cfn invoke for each of CRUDL/cfn test
- [x] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [x] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

