### PR TITLE
chore: Removes CFN Test from cleanup process

### DIFF
--- a/.github/workflows/cleanup-test-env.yml
+++ b/.github/workflows/cleanup-test-env.yml
@@ -24,11 +24,3 @@ jobs:
           MONGODB_ATLAS_OPS_MANAGER_URL: ${{ vars.MONGODB_ATLAS_BASE_URL }}
           PROJECT_TO_NOT_DELETE: ${{ vars.CLOUD_DEV_PROJECT_ID }}
         run: ./scripts/cleanup-test-env.sh      
-      - name: Cleanup cloud-dev CFNTest
-        shell: bash
-        env:
-          MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.CLOUD_DEV_CFN_TEST_PUBLIC_KEY }}
-          MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.CLOUD_DEV_CFN_TEST_PRIVATE_KEY }}
-          MONGODB_ATLAS_ORG_ID: ${{ secrets.CLOUD_DEV_CFN_TEST_ORG_ID }}
-          MONGODB_ATLAS_OPS_MANAGER_URL: ${{ vars.MONGODB_ATLAS_BASE_URL }}
-        run: ./scripts/cleanup-test-env.sh      


### PR DESCRIPTION
Removes CFN Test from cleanup process

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

