### PR TITLE
fix: Add missing MicrosoftTeamsWebhookUrl to alert notification configuration

### DIFF
--- a/cfn-resources/alert-configuration/cmd/resource/resource.go
+++ b/cfn-resources/alert-configuration/cmd/resource/resource.go
@@ -325,28 +325,28 @@ func expandAlertConfigurationNotification(notificationList []NotificationView) (
 	}
 
 	for ind := range notificationList {
-                notification := atlasSDK.AlertsNotificationRootForGroup{
-                        ApiToken:                 notificationList[ind].ApiToken,
-                        ChannelName:              notificationList[ind].ChannelName,
-                        DatadogApiKey:            notificationList[ind].DatadogApiKey,
-                        DatadogRegion:            notificationList[ind].DatadogRegion,
-                        EmailAddress:             notificationList[ind].EmailAddress,
-                        EmailEnabled:             notificationList[ind].EmailEnabled,
-                        IntervalMin:              util.Pointer(int(*notificationList[ind].IntervalMin)),
-                        MicrosoftTeamsWebhookUrl: notificationList[ind].MicrosoftTeamsWebhookUrl,
-                        MobileNumber:             notificationList[ind].MobileNumber,
-                        OpsGenieApiKey:           notificationList[ind].OpsGenieApiKey,
-                        OpsGenieRegion:           notificationList[ind].OpsGenieRegion,
-                        ServiceKey:               notificationList[ind].ServiceKey,
-                        SmsEnabled:               notificationList[ind].SmsEnabled,
-                        TeamId:                   notificationList[ind].TeamId,
-                        TypeName:                 notificationList[ind].TypeName,
-                        Username:                 notificationList[ind].Username,
-                        VictorOpsApiKey:          notificationList[ind].VictorOpsApiKey,
-                        VictorOpsRoutingKey:      notificationList[ind].VictorOpsRoutingKey,
-                        Roles:                    cast.ToStringSlice(notificationList[ind].Roles),
-                        DelayMin:                 notificationList[ind].DelayMin,
-                }
+		notification := atlasSDK.AlertsNotificationRootForGroup{
+			ApiToken:                 notificationList[ind].ApiToken,
+			ChannelName:              notificationList[ind].ChannelName,
+			DatadogApiKey:            notificationList[ind].DatadogApiKey,
+			DatadogRegion:            notificationList[ind].DatadogRegion,
+			EmailAddress:             notificationList[ind].EmailAddress,
+			EmailEnabled:             notificationList[ind].EmailEnabled,
+			IntervalMin:              util.Pointer(int(*notificationList[ind].IntervalMin)),
+			MicrosoftTeamsWebhookUrl: notificationList[ind].MicrosoftTeamsWebhookUrl,
+			MobileNumber:             notificationList[ind].MobileNumber,
+			OpsGenieApiKey:           notificationList[ind].OpsGenieApiKey,
+			OpsGenieRegion:           notificationList[ind].OpsGenieRegion,
+			ServiceKey:               notificationList[ind].ServiceKey,
+			SmsEnabled:               notificationList[ind].SmsEnabled,
+			TeamId:                   notificationList[ind].TeamId,
+			TypeName:                 notificationList[ind].TypeName,
+			Username:                 notificationList[ind].Username,
+			VictorOpsApiKey:          notificationList[ind].VictorOpsApiKey,
+			VictorOpsRoutingKey:      notificationList[ind].VictorOpsRoutingKey,
+			Roles:                    cast.ToStringSlice(notificationList[ind].Roles),
+			DelayMin:                 notificationList[ind].DelayMin,
+		}
 		notifications = append(notifications, notification)
 	}
 	return notifications, nil

--- a/cfn-resources/alert-configuration/cmd/resource/resource.go
+++ b/cfn-resources/alert-configuration/cmd/resource/resource.go
@@ -325,28 +325,28 @@ func expandAlertConfigurationNotification(notificationList []NotificationView) (
 	}
 
 	for ind := range notificationList {
-		notification := atlasSDK.AlertsNotificationRootForGroup{
-			ApiToken:            notificationList[ind].ApiToken,
-			ChannelName:         notificationList[ind].ChannelName,
-			DatadogApiKey:       notificationList[ind].DatadogApiKey,
-			DatadogRegion:       notificationList[ind].DatadogRegion,
-			EmailAddress:        notificationList[ind].EmailAddress,
-			EmailEnabled:        notificationList[ind].EmailEnabled,
-			IntervalMin:         util.Pointer(int(*notificationList[ind].IntervalMin)),
-			MicrosoftTeamsWebhookUrl: notificationList[ind].MicrosoftTeamsWebhookUrl,
-			MobileNumber:        notificationList[ind].MobileNumber,
-			OpsGenieApiKey:      notificationList[ind].OpsGenieApiKey,
-			OpsGenieRegion:      notificationList[ind].OpsGenieRegion,
-			ServiceKey:          notificationList[ind].ServiceKey,
-			SmsEnabled:          notificationList[ind].SmsEnabled,
-			TeamId:              notificationList[ind].TeamId,
-			TypeName:            notificationList[ind].TypeName,
-			Username:            notificationList[ind].Username,
-			VictorOpsApiKey:     notificationList[ind].VictorOpsApiKey,
-			VictorOpsRoutingKey: notificationList[ind].VictorOpsRoutingKey,
-			Roles:               cast.ToStringSlice(notificationList[ind].Roles),
-			DelayMin:            notificationList[ind].DelayMin,
-		}
+                notification := atlasSDK.AlertsNotificationRootForGroup{
+                        ApiToken:                 notificationList[ind].ApiToken,
+                        ChannelName:              notificationList[ind].ChannelName,
+                        DatadogApiKey:            notificationList[ind].DatadogApiKey,
+                        DatadogRegion:            notificationList[ind].DatadogRegion,
+                        EmailAddress:             notificationList[ind].EmailAddress,
+                        EmailEnabled:             notificationList[ind].EmailEnabled,
+                        IntervalMin:              util.Pointer(int(*notificationList[ind].IntervalMin)),
+                        MicrosoftTeamsWebhookUrl: notificationList[ind].MicrosoftTeamsWebhookUrl,
+                        MobileNumber:             notificationList[ind].MobileNumber,
+                        OpsGenieApiKey:           notificationList[ind].OpsGenieApiKey,
+                        OpsGenieRegion:           notificationList[ind].OpsGenieRegion,
+                        ServiceKey:               notificationList[ind].ServiceKey,
+                        SmsEnabled:               notificationList[ind].SmsEnabled,
+                        TeamId:                   notificationList[ind].TeamId,
+                        TypeName:                 notificationList[ind].TypeName,
+                        Username:                 notificationList[ind].Username,
+                        VictorOpsApiKey:          notificationList[ind].VictorOpsApiKey,
+                        VictorOpsRoutingKey:      notificationList[ind].VictorOpsRoutingKey,
+                        Roles:                    cast.ToStringSlice(notificationList[ind].Roles),
+                        DelayMin:                 notificationList[ind].DelayMin,
+                }
 		notifications = append(notifications, notification)
 	}
 	return notifications, nil

--- a/cfn-resources/alert-configuration/cmd/resource/resource.go
+++ b/cfn-resources/alert-configuration/cmd/resource/resource.go
@@ -333,6 +333,7 @@ func expandAlertConfigurationNotification(notificationList []NotificationView) (
 			EmailAddress:        notificationList[ind].EmailAddress,
 			EmailEnabled:        notificationList[ind].EmailEnabled,
 			IntervalMin:         util.Pointer(int(*notificationList[ind].IntervalMin)),
+			MicrosoftTeamsWebhookUrl: notificationList[ind].MicrosoftTeamsWebhookUrl,
 			MobileNumber:        notificationList[ind].MobileNumber,
 			OpsGenieApiKey:      notificationList[ind].OpsGenieApiKey,
 			OpsGenieRegion:      notificationList[ind].OpsGenieRegion,


### PR DESCRIPTION
## Proposed changes

The MicrosoftTeamsWebhookUrl property is not copied into alert notification configurations.

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] **Do not know how to do this.** I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [ ] **Do not know how to do this.** For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas