### PR TITLE
chore: Makes automation script less verbose

### DIFF
--- a/cfn-resources/tool/cfn-publishing-automation/cfn-3P-provider-register.yaml
+++ b/cfn-resources/tool/cfn-publishing-automation/cfn-3P-provider-register.yaml
@@ -87,8 +87,8 @@ mainSteps:
             build:
               commands:
                 - aws --version
-                - wget "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
-                - unzip aws-sam-cli-linux-x86_64.zip -d sam-installation
+                - wget -q "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
+                - unzip -q aws-sam-cli-linux-x86_64.zip -d sam-installation
                 - ./sam-installation/install
                 - pip3 install cloudformation-cli cloudformation-cli-go-plugin
                 - export MONGODB_ATLAS_BASE_URL={{BaseUrl}}


### PR DESCRIPTION
## Proposed changes

Makes automation script less verbose by adding -q flags to wget and unzip

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

