### PR TITLE
fix: Allows not setting optional attributes DataProcessRegion and CloudProviderConfig for `FederatedDatabaseInstance`

### DIFF
--- a/cfn-resources/federated-database-instance/cmd/resource/resource.go
+++ b/cfn-resources/federated-database-instance/cmd/resource/resource.go
@@ -279,6 +279,10 @@ func (model *Model) setDataLakeTenant() (dataLakeTenant atlasSDK.DataLakeTenant)
 			Region:        *dataProcessRegion.Region,
 		}
 	}
+	if dataProcessRegion.Region != nil {
+		dataLakeTenant.DataProcessRegion.CloudProvider = constants.AWS
+		dataLakeTenant.DataProcessRegion.Region = *dataProcessRegion.Region
+	}
 
 	return dataLakeTenant
 }

--- a/cfn-resources/federated-database-instance/cmd/resource/resource.go
+++ b/cfn-resources/federated-database-instance/cmd/resource/resource.go
@@ -75,7 +75,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 			DataLakeTenant: &dataLakeTenantInput,
 		}).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, CREATE, err)
 	}
@@ -108,7 +107,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	dataLakeTenant, response, err := client.AtlasSDK.DataFederationApi.GetFederatedDatabase(context.Background(), *currentModel.ProjectId, *currentModel.TenantName).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, READ, err)
 	}
@@ -149,7 +147,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	updateFederatedDatabaseAPIRequest = updateFederatedDatabaseAPIRequest.SkipRoleValidation(*currentModel.SkipRoleValidation)
 	dataLakeTenant, response, err := updateFederatedDatabaseAPIRequest.Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, UPDATE, err)
 	}
@@ -182,7 +179,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	_, response, err := client.AtlasSDK.DataFederationApi.DeleteFederatedDatabase(context.Background(), *currentModel.ProjectId, *currentModel.TenantName).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, DELETE, err)
 	}
@@ -213,7 +209,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 	dataLakeTenants, response, err := client.AtlasSDK.DataFederationApi.ListFederatedDatabases(context.Background(), *currentModel.ProjectId).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, LIST, err)
 	}

--- a/cfn-resources/federated-database-instance/cmd/resource/resource.go
+++ b/cfn-resources/federated-database-instance/cmd/resource/resource.go
@@ -225,12 +225,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		ResourceModels:  tenants}, nil
 }
 
-func closeResponse(response *http.Response) {
-	if response != nil {
-		response.Body.Close()
-	}
-}
-
 func handleError(response *http.Response, method string, err error) (handler.ProgressEvent, error) {
 	_, _ = logger.Warnf("%s failed, error: %s", method, err.Error())
 	if response.StatusCode == http.StatusConflict {

--- a/cfn-resources/federated-database-instance/cmd/resource/resource.go
+++ b/cfn-resources/federated-database-instance/cmd/resource/resource.go
@@ -279,9 +279,12 @@ func (model *Model) setDataLakeTenant() (dataLakeTenant atlasSDK.DataLakeTenant)
 			Region:        *dataProcessRegion.Region,
 		}
 	}
-	if dataProcessRegion.Region != nil {
-		dataLakeTenant.DataProcessRegion.CloudProvider = constants.AWS
-		dataLakeTenant.DataProcessRegion.Region = *dataProcessRegion.Region
+
+	if dataProcessRegion != nil && dataProcessRegion.Region != nil {
+		dataLakeTenant.DataProcessRegion = &atlasSDK.DataLakeDataProcessRegion{
+			CloudProvider: constants.AWS,
+			Region:        *dataProcessRegion.Region,
+		}
 	}
 
 	return dataLakeTenant

--- a/cfn-resources/federated-database-instance/docs/dataprocessregion.md
+++ b/cfn-resources/federated-database-instance/docs/dataprocessregion.md
@@ -38,7 +38,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 Name of the region to which the data lake routes client connections.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 

--- a/cfn-resources/federated-database-instance/mongodb-atlas-federateddatabaseinstance.json
+++ b/cfn-resources/federated-database-instance/mongodb-atlas-federateddatabaseinstance.json
@@ -356,10 +356,7 @@
   ],
   "required": [
     "ProjectId",
-    "TenantName",
-    "CloudProviderConfig/RoleId",
-    "CloudProviderConfig/TestS3Bucket",
-    "DataProcessRegion/Region"
+    "TenantName"
   ],
   "primaryIdentifier": [
     "/properties/ProjectId",

--- a/cfn-resources/federated-database-instance/mongodb-atlas-federateddatabaseinstance.json
+++ b/cfn-resources/federated-database-instance/mongodb-atlas-federateddatabaseinstance.json
@@ -41,6 +41,9 @@
           "description": "Name of the region to which the data lake routes client connections."
         }
       },
+      "required": [
+        "Region"
+      ],
       "additionalProperties": false
     },
     "Storage": {

--- a/cfn-resources/federated-database-instance/test/data-federation-sample-request.json
+++ b/cfn-resources/federated-database-instance/test/data-federation-sample-request.json
@@ -1,0 +1,17 @@
+{
+  "desiredResourceState": {
+    "TenantName": "oriol-tests-testing-locally-10",
+    "ProjectId": "65dca009938ec8392b94e7e6",
+    "Profile": "default-oriol",
+    "Storage": {
+      "Databases": [
+        {
+          "MaxWildcardCollections": "50",
+          "Name": "sample-mflix"
+        }
+      ]
+    }
+  },
+  "providerLogGroupName": "mongodb-atlas-data-federation-logs",
+  "previousResourceState": {}
+}

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -385,6 +385,13 @@ func IntPtrToStrPtr(i *int) *string {
 	return &str
 }
 
+func StringPtr(v string) *string {
+	if v != "" {
+		return &v
+	}
+	return nil
+}
+
 func SameStringSliceWithoutOrder(x, y []string) bool {
 	if len(x) != len(y) {
 		return false


### PR DESCRIPTION

## Proposed changes

Fixes bug where creation of resource was not possible without setting values for optional attributes DataProcessRegion and CloudProviderConfig.
Now it's possible to create a `FederatedDatabaseInstance` without setting those attributes

Some opportunistic improvements in the code have been maded in the resource.

Link to any related issue(s): CLOUDP-219922


## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [x] cfn invoke for each of CRUDL/cfn test
- [x] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [x] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments
Tests results:
<img width="776" alt="Screenshot 2024-04-24 at 09 42 38" src="https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/55513886/aec86e68-bc81-460f-8313-dd5389b9ba31">
Stack creation and update:
<img width="1080" alt="Screenshot 2024-04-24 at 09 55 29" src="https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/55513886/b0155e31-b293-4b88-a433-46d21dff13c8">
Atlas UI after creation:
<img width="1128" alt="Screenshot 2024-04-24 at 09 55 38" src="https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/55513886/71b40075-aecf-4cca-aeb0-fdf033f41cb5">




