### PR TITLE
chore: Removes defer closeResponse

### DIFF
--- a/cfn-resources/access-list-api-key/cmd/resource/resource.go
+++ b/cfn-resources/access-list-api-key/cmd/resource/resource.go
@@ -102,7 +102,6 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	createAccessListAPIKey := client.Atlas20231115002.ProgrammaticAPIKeysApi.CreateApiKeyAccessList(context.Background(), orgID, apiKeyID, &entryList)
 	_, response, err := createAccessListAPIKey.Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		_, _ = logger.Warnf("Execute error: %s", err.Error())
 		return handleError(response, CREATE, err)
@@ -158,7 +157,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	readAccessListAPIKey := client.Atlas20231115002.ProgrammaticAPIKeysApi.GetApiKeyAccessList(context.Background(), orgID, *access.IpAddress, apiKeyID)
 	_, response, err := readAccessListAPIKey.Execute()
-	defer closeResponse(response)
 	if err != nil {
 		_, _ = logger.Warnf("Execute error: %s", err.Error())
 		return handleError(response, READ, err)
@@ -218,7 +216,6 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	deleteAccessListAPIKey := client.Atlas20231115002.ProgrammaticAPIKeysApi.DeleteApiKeyAccessListEntry(context.Background(), orgID, apiKeyID, *access.IpAddress)
 	_, response, err := deleteAccessListAPIKey.Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		_, _ = logger.Warnf("Execute error: %s", err.Error())
 		return handleError(response, DELETE, err)
@@ -250,11 +247,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	orgID := *currentModel.OrgId
 	apiKeyID := *currentModel.APIUserId
 
-	listAccessListAPIKey := client.Atlas20231115002.ProgrammaticAPIKeysApi.ListApiKeyAccessListsEntries(context.Background(), orgID, apiKeyID)
-
-	accessListResponse, response, err := listAccessListAPIKey.Execute()
-
-	defer closeResponse(response)
+	accessListResponse, response, err := client.Atlas20231115002.ProgrammaticAPIKeysApi.ListApiKeyAccessListsEntries(context.Background(), orgID, apiKeyID).Execute()
 
 	if err != nil {
 		_, _ = logger.Warnf("Execute error: %s", err.Error())
@@ -278,15 +271,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		Message:         "List Complete",
 		ResourceModels:  accessListModels,
 	}, nil
-}
-
-func closeResponse(response *http.Response) {
-	if response != nil {
-		err := response.Body.Close()
-		if err != nil {
-			return
-		}
-	}
 }
 
 func handleError(response *http.Response, method string, err error) (handler.ProgressEvent, error) {

--- a/cfn-resources/data-lake-pipeline/cmd/resource/resource.go
+++ b/cfn-resources/data-lake-pipeline/cmd/resource/resource.go
@@ -66,11 +66,8 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	groupID := *currentModel.ProjectId
 	dataLakeIntegrationPipeline := generateDataLakeIntegrationPipeline(currentModel)
 
-	createRequest := client.Atlas20231115002.DataLakePipelinesApi.CreatePipeline(ctx.Background(), groupID, dataLakeIntegrationPipeline)
+	pe, response, err := client.Atlas20231115002.DataLakePipelinesApi.CreatePipeline(ctx.Background(), groupID, dataLakeIntegrationPipeline).Execute()
 
-	pe, response, err := createRequest.Execute()
-
-	defer closeResponse(response)
 	if err != nil {
 		if response.StatusCode == http.StatusBadRequest {
 			return handler.ProgressEvent{
@@ -151,10 +148,8 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	groupID := *currentModel.ProjectId
 	pipelineName := *currentModel.Name
 
-	readRequest := client.Atlas20231115002.DataLakePipelinesApi.GetPipeline(ctx.Background(), groupID, pipelineName)
-	pe, response, err := readRequest.Execute()
+	pe, response, err := client.Atlas20231115002.DataLakePipelinesApi.GetPipeline(ctx.Background(), groupID, pipelineName).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, err)
 	}
@@ -250,10 +245,8 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	pipelineName := *currentModel.Name
 	dataLakeIntegrationPipeline := generateDataLakeIntegrationPipeline(currentModel)
 
-	updateRequest := client.Atlas20231115002.DataLakePipelinesApi.UpdatePipeline(ctx.Background(), groupID, pipelineName, dataLakeIntegrationPipeline)
-	pe, response, err := updateRequest.Execute()
+	pe, response, err := client.Atlas20231115002.DataLakePipelinesApi.UpdatePipeline(ctx.Background(), groupID, pipelineName, dataLakeIntegrationPipeline).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		if response.StatusCode == http.StatusBadRequest {
 			return progress_events.GetFailedEventByCode(fmt.Sprintf("Error during execution : %s", err.Error()),
@@ -296,10 +289,8 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	groupID := *currentModel.ProjectId
 	pipelineName := *currentModel.Name
 
-	deleteRequest := client.Atlas20231115002.DataLakePipelinesApi.DeletePipeline(ctx.Background(), groupID, pipelineName)
-	_, response, err := deleteRequest.Execute()
+	_, response, err := client.Atlas20231115002.DataLakePipelinesApi.DeletePipeline(ctx.Background(), groupID, pipelineName).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, err)
 	}
@@ -329,10 +320,8 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	}
 
 	groupID := *currentModel.ProjectId
-	readAllRequest := client.Atlas20231115002.DataLakePipelinesApi.ListPipelines(ctx.Background(), groupID)
+	pe, response, err := client.Atlas20231115002.DataLakePipelinesApi.ListPipelines(ctx.Background(), groupID).Execute()
 
-	pe, response, err := readAllRequest.Execute()
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, err)
 	}
@@ -362,10 +351,4 @@ func handleError(response *http.Response, err error) (handler.ProgressEvent, err
 			HandlerErrorCode: cloudformation.HandlerErrorCodeAlreadyExists}, nil
 	}
 	return progress_events.GetFailedEventByResponse(fmt.Sprintf("Error during execution : %s", err.Error()), response), nil
-}
-
-func closeResponse(response *http.Response) {
-	if response != nil {
-		response.Body.Close()
-	}
 }

--- a/cfn-resources/privatelink-endpoint-service-data-federation-online-archive/cmd/resource/resource.go
+++ b/cfn-resources/privatelink-endpoint-service-data-federation-online-archive/cmd/resource/resource.go
@@ -64,7 +64,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	readModel := Model{ProjectId: currentModel.ProjectId, EndpointId: currentModel.EndpointId}
 	readResponse, err := readModel.getPrivateEndpoint(atlas)
-	defer closeResponse(readResponse)
+
 	if err == nil {
 		return handler.ProgressEvent{
 			OperationStatus:  handler.Failed,
@@ -74,14 +74,13 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	response, err := createOrUpdate(currentModel, atlas)
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, err)
 	}
 
 	// Read endpoint
 	readResponse, err = currentModel.getPrivateEndpoint(atlas)
-	defer closeResponse(readResponse)
+
 	if err != nil {
 		return handleError(readResponse, err)
 	}
@@ -129,7 +128,6 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	response, err := currentModel.getPrivateEndpoint(atlas)
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, err)
 	}
@@ -159,20 +157,19 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	readModel := Model{ProjectId: currentModel.ProjectId, EndpointId: currentModel.EndpointId}
 	readResponse, err := readModel.getPrivateEndpoint(atlas)
-	defer closeResponse(readResponse)
+
 	if err != nil {
 		return handleError(readResponse, err)
 	}
 	response, err := createOrUpdate(currentModel, atlas)
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, err)
 	}
 
 	// Read endpoint
 	readResponse, err = currentModel.getPrivateEndpoint(atlas)
-	defer closeResponse(readResponse)
+
 	if err != nil {
 		return handleError(readResponse, err)
 	}
@@ -202,14 +199,12 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return *peErr, nil
 	}
 
-	deleteRequest := client.Atlas20231115002.DataFederationApi.DeleteDataFederationPrivateEndpoint(
+	_, response, err := client.Atlas20231115002.DataFederationApi.DeleteDataFederationPrivateEndpoint(
 		ctx.Background(),
 		*currentModel.ProjectId,
 		*currentModel.EndpointId,
-	)
-	_, response, err := deleteRequest.Execute()
+	).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, err)
 	}
@@ -238,13 +233,11 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return *peErr, nil
 	}
 
-	listRequest := client.Atlas20231115002.DataFederationApi.ListDataFederationPrivateEndpoints(
+	pe, response, err := client.Atlas20231115002.DataFederationApi.ListDataFederationPrivateEndpoints(
 		ctx.Background(),
 		*currentModel.ProjectId,
-	)
-	pe, response, err := listRequest.Execute()
+	).Execute()
 
-	defer closeResponse(response)
 	if err != nil {
 		return handleError(response, err)
 	}
@@ -277,12 +270,6 @@ func (model *Model) getPrivateEndpoint(client *util.MongoDBClient) (*http.Respon
 	}
 	model.readPrivateEndpoint(paginatedPrivateNetworkEndpointIDEntry)
 	return response, err
-}
-
-func closeResponse(response *http.Response) {
-	if response != nil {
-		response.Body.Close()
-	}
 }
 
 func (model *Model) readPrivateEndpoint(pe *atlasSDK.PrivateNetworkEndpointIdEntry) *Model {

--- a/cfn-resources/privatelink-endpoint-service-data-federation-online-archive/cmd/resource/resource.go
+++ b/cfn-resources/privatelink-endpoint-service-data-federation-online-archive/cmd/resource/resource.go
@@ -63,7 +63,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	readModel := Model{ProjectId: currentModel.ProjectId, EndpointId: currentModel.EndpointId}
-	readResponse, err := readModel.getPrivateEndpoint(atlas)
+	_, err := readModel.getPrivateEndpoint(atlas)
 
 	if err == nil {
 		return handler.ProgressEvent{
@@ -79,7 +79,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	// Read endpoint
-	readResponse, err = currentModel.getPrivateEndpoint(atlas)
+	readResponse, err := currentModel.getPrivateEndpoint(atlas)
 
 	if err != nil {
 		return handleError(readResponse, err)


### PR DESCRIPTION

## Proposed changes

- Remove defer closeResponse because this is already being done in the SDK
- Refactor requests

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

