### PR TITLE
chore: Fixes creates test data for project during publishing

### DIFF
--- a/cfn-resources/project/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/project/test/cfn-test-create-inputs.sh
@@ -42,7 +42,7 @@ api_key_id=$(atlas organizations apikeys create --desc "cfn-boto-key-${CFN_TEST_
 team_name="cfn-boto-team-${CFN_TEST_TAG}"
 user_name=$(atlas organizations users list --output json | jq -r '.results[0].emailAddress')
 echo "${user_name}"
-team_id=$(atlas teams describe --name "$team_name" --output json | jq -r ".id")
+team_id=$(atlas teams describe --name "$team_name" --output json | jq -r ".id") || echo ""
 if [ -z "$team_id" ]; then
 	team_id=$(atlas team create "${team_name}" --username "${user_name}" --orgId "${org_id}" --output json | jq -r '.id')
 fi
@@ -74,4 +74,3 @@ jq --arg org "${org_id}" \
 	"test/inputs_2_update.template.json" >"inputs/inputs_2_update.json"
 
 ls -l inputs
-echo "TODO: Delete the team and api_key created above"

--- a/cfn-resources/project/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/project/test/cfn-test-create-inputs.sh
@@ -21,6 +21,8 @@
 # This tool generates json files in the inputs/ for `cfn test`.
 #
 
+set -euo pipefail
+
 function usage {
 	echo "usage:$0 <project_name>"
 }
@@ -63,12 +65,12 @@ jq --arg org "$MONGODB_ATLAS_ORG_ID" \
 
 jq --arg org "${org_id}" \
 	--arg name "${name}-tags" \
-	'.OrgId?|=$org |.Name?|=$name |.Profile?|=$profile' \
+	'.OrgId?|=$org |.Name?|=$name' \
 	"test/inputs_2_create.template.json" >"inputs/inputs_2_create.json"
 
 jq --arg org "${org_id}" \
 	--arg name "${name}"-tags \
-	'.OrgId?|=$org |.Name?|=$name |.Profile?|=$profile' \
+	'.OrgId?|=$org |.Name?|=$name' \
 	"test/inputs_2_update.template.json" >"inputs/inputs_2_update.json"
 
 ls -l inputs


### PR DESCRIPTION
## Proposed changes

Fixes creates test data for project during publishing

Link to any related issue(s): 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

