### PR TITLE
fix: Enable defining multiple access-list-api-keys resources in a single stack

### DIFF
--- a/cfn-resources/access-list-api-key/CHANGELOG.md
+++ b/cfn-resources/access-list-api-key/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 3.0.0
+
+- Format of the primary id was modified to enable creating multiple AccessListAPIKey resources in a single stack.
+- `CidrBlock` property is now fully supported avoiding errors during read and delete operations.

--- a/cfn-resources/access-list-api-key/cmd/resource/model.go
+++ b/cfn-resources/access-list-api-key/cmd/resource/model.go
@@ -8,6 +8,7 @@ type Model struct {
 	APIUserId  *string `json:",omitempty"`
 	Profile    *string `json:",omitempty"`
 	CidrBlock  *string `json:",omitempty"`
+	Entry      *string `json:",omitempty"`
 	IpAddress  *string `json:",omitempty"`
 	TotalCount *int    `json:",omitempty"`
 }

--- a/cfn-resources/access-list-api-key/cmd/resource/resource.go
+++ b/cfn-resources/access-list-api-key/cmd/resource/resource.go
@@ -108,7 +108,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return handleError(response, CREATE, err)
 	}
 
-	setUniqueEntryInModel(currentModel)
+	setEntryInModel(currentModel)
 
 	return handler.ProgressEvent{
 		OperationStatus: handler.Success,
@@ -234,13 +234,9 @@ func getEntryAddress(currentModel *Model) string {
 }
 
 // Populate Entry read-only property that is part of the primary id of the resource
-func setUniqueEntryInModel(currentModel *Model) {
-	if currentModel.CidrBlock != nil {
-		currentModel.Entry = currentModel.CidrBlock
-	}
-	if currentModel.IpAddress != nil {
-		currentModel.Entry = currentModel.IpAddress
-	}
+func setEntryInModel(currentModel *Model) {
+	uniqueAddress := getEntryAddress(currentModel)
+	currentModel.Entry = &uniqueAddress
 }
 
 // List handles the List event from the Cloudformation service.
@@ -281,6 +277,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 			Profile:   currentModel.Profile,
 			IpAddress: l.IpAddress,
 		}
+		setEntryInModel(&label) // having all results with the Entry property is required so the primary id is complete
 		accessListModels = append(accessListModels, label)
 	}
 	return handler.ProgressEvent{

--- a/cfn-resources/access-list-api-key/cmd/resource/resource.go
+++ b/cfn-resources/access-list-api-key/cmd/resource/resource.go
@@ -108,6 +108,8 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return handleError(response, CREATE, err)
 	}
 
+	setUniqueEntryInModel(currentModel)
+
 	return handler.ProgressEvent{
 		OperationStatus: handler.Success,
 		Message:         "Create Complete",
@@ -229,6 +231,16 @@ func getEntryAddress(currentModel *Model) string {
 		entry = *currentModel.IpAddress
 	}
 	return entry
+}
+
+// Populate Entry read-only property that is part of the primary id of the resource
+func setUniqueEntryInModel(currentModel *Model) {
+	if currentModel.CidrBlock != nil {
+		currentModel.Entry = currentModel.CidrBlock
+	}
+	if currentModel.IpAddress != nil {
+		currentModel.Entry = currentModel.IpAddress
+	}
 }
 
 // List handles the List event from the Cloudformation service.

--- a/cfn-resources/access-list-api-key/docs/README.md
+++ b/cfn-resources/access-list-api-key/docs/README.md
@@ -107,5 +107,5 @@ For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::G
 
 #### Entry
 
-Contains the value of IpAddress or CidrBlock for uniquely identifying the resource.
+Value that uniquely identifies the access list entry.
 

--- a/cfn-resources/access-list-api-key/docs/README.md
+++ b/cfn-resources/access-list-api-key/docs/README.md
@@ -97,3 +97,15 @@ _Type_: Integer
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
+## Return Values
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### Entry
+
+Contains the value of IpAddress or CidrBlock for uniquely identifying the resource.
+

--- a/cfn-resources/access-list-api-key/mongodb-atlas-accesslistapikey.json
+++ b/cfn-resources/access-list-api-key/mongodb-atlas-accesslistapikey.json
@@ -22,7 +22,7 @@
     },
     "Entry": {
       "type": "string",
-      "description": "Contains the value of IpAddress or CidrBlock for uniquely identifying the resource."
+      "description": "Value that uniquely identifies the access list entry."
     },
     "IpAddress": {
       "description": "Network address that you want to add to the access list for the API key.",

--- a/cfn-resources/access-list-api-key/mongodb-atlas-accesslistapikey.json
+++ b/cfn-resources/access-list-api-key/mongodb-atlas-accesslistapikey.json
@@ -20,6 +20,10 @@
       "description": "Range of network addresses that you want to add to the access list for the API key.",
       "type": "string"
     },
+    "Entry": {
+      "type": "string",
+      "description": "Contains the value of IpAddress or CidrBlock for uniquely identifying the resource."
+    },
     "IpAddress": {
       "description": "Network address that you want to add to the access list for the API key.",
       "type": "string"
@@ -39,10 +43,14 @@
     "/properties/APIUserId",
     "/properties/Profile"
   ],
+  "readOnlyProperties": [
+    "/properties/Entry"
+  ],
   "primaryIdentifier": [
     "/properties/OrgId",
     "/properties/APIUserId",
-    "/properties/Profile"
+    "/properties/Profile",
+    "/properties/Entry"
   ],
   "handlers": {
     "create": {


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-250925

Defines a new read only property `Entry` that is included as part of the primary id of the access-list-api-keys resource. The value of this property is simply `IdAddress` or `CidrBlock` which are required and mutually exclusive (validated during the create operation).

Why not include `IdAddress` and `CidrBlock` directly as part of the primary id? When trying this approach the following error is encountered because one of these properties will be empty and this is not supported by CFN (all primary id properties must be present):
`Create handler did not return the primaryIdentifier for the physical resource`

### Testing

Example stack:
```
"Resources": {
      "FirstAPIKeyEntry": {
        "Type": "MongoDB::Atlas::AccessListAPIKey",
        "Properties": {
          "OrgId": "64b6bf4c1f89ae5ca0f0d849",
          "IpAddress": "203.0.113.13",
          "APIUserId": "6654577a74a113283a2f32b5",
          "Profile": "default"
        }
      },
      "SecondAPIKeyEntry": {
        "Type": "MongoDB::Atlas::AccessListAPIKey",
        "Properties": {
          "OrgId": "64b6bf4c1f89ae5ca0f0d849",
          "CidrBlock": "203.0.113.14/32",
          "APIUserId": "6654577a74a113283a2f32b5",
          "Profile": "default"
        }
      }
    },
```

Before:
`64b6bf4c1f89ae5ca0f0d849|6654577a74a113283a2f32b5|default already exists in stack arn:aws:cloudformation:eu-north-1:358363220050:stack/creating-two-ip-address-entries/0bdbbc20-2251-11ef-9ecc-0a1b85bf14e4`

After:
![Screenshot 2024-06-04 at 11 45 22](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/9747c57d-2379-4be0-8a14-a44f60b5d481)

![Screenshot 2024-06-04 at 15 53 40](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/20469408/0baf4352-33bc-48e2-bc68-519e587cf81a)

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [x] Published to AWS private registry
- [x] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [x] Deleted stack to ensure resources are deleted
- [x] Created multiple resources in same stack
- [x] Validated in Atlas UI
- [x] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

