### PR TITLE
fix: Edits to replication specs for cluster

### DIFF
--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -11,6 +11,7 @@ jobs:
       pull-requests: read
       repository-projects: read
     outputs:
+      cluster: ${{ steps.filter.outputs.cluster }}
       project: ${{ steps.filter.outputs.project }}
       search-deployment: ${{ steps.filter.outputs.search-deployment }}
     steps:

--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -20,12 +20,45 @@ jobs:
         id: filter
         with:
           filters: |
+            cluster:
+              - 'cfn-resources/cluster/**'
+              - 'cfn-resources/test/e2e/cluster/**'
             project:
               - 'cfn-resources/project/**'
               - 'cfn-resources/test/e2e/project/**'
             search-deployment:
               - 'cfn-resources/search-deployment/**'
               - 'cfn-resources/test/e2e/search-deployment/**'
+  cluster:
+    needs: change-detection
+    if: ${{ needs.change-detection.outputs.cluster == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - run: pip install cloudformation-cli-go-plugin
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+        with:
+          go-version-file: 'cfn-resources/go.mod'
+      - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_TEST_ENV }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_TEST_ENV }}
+          aws-region: eu-west-1
+      - name: Run E2E test
+        shell: bash
+        env:
+          MONGODB_ATLAS_PUBLIC_KEY: ${{ secrets.CLOUD_DEV_PUBLIC_KEY }}
+          MONGODB_ATLAS_PRIVATE_KEY: ${{ secrets.CLOUD_DEV_PRIVATE_KEY }}
+          MONGODB_ATLAS_ORG_ID: ${{ secrets.CLOUD_DEV_ORG_ID }}
+          MONGODB_ATLAS_BASE_URL: https://cloud-dev.mongodb.com/
+          MONGODB_ATLAS_SECRET_PROFILE: cfn-cloud-dev-github-action
+        run: |
+          cd cfn-resources/test/e2e/cluster
+          go test -timeout 60m -v cluster_test.go
   project:
     needs: change-detection
     if: ${{ needs.change-detection.outputs.project == 'true' }}

--- a/.github/workflows/e2e-testing.yaml
+++ b/.github/workflows/e2e-testing.yaml
@@ -59,7 +59,7 @@ jobs:
           MONGODB_ATLAS_SECRET_PROFILE: cfn-cloud-dev-github-action
         run: |
           cd cfn-resources/test/e2e/cluster
-          go test -timeout 60m -v cluster_test.go
+          go test -timeout 90m -v cluster_test.go
   project:
     needs: change-detection
     if: ${{ needs.change-detection.outputs.project == 'true' }}

--- a/cfn-resources/cluster/cmd/resource/mappings.go
+++ b/cfn-resources/cluster/cmd/resource/mappings.go
@@ -649,7 +649,7 @@ func setClusterRequest(currentModel *Model) (*admin.AdvancedClusterDescription, 
 
 func PopulateReplicationSpecIds(src, dest []admin.ReplicationSpec) *[]admin.ReplicationSpec {
 	zoneToID := map[string]string{}
-	providerRegionToId := map[string]string{}
+	providerRegionToID := map[string]string{}
 	usedIds := map[string]bool{}
 
 	for _, spec := range src {
@@ -661,7 +661,7 @@ func PopulateReplicationSpecIds(src, dest []admin.ReplicationSpec) *[]admin.Repl
 			zoneToID[zoneName] = specID
 		}
 		if providerRegion := asProviderRegion(spec); providerRegion != "" {
-			providerRegionToId[providerRegion] = spec.GetId()
+			providerRegionToID[providerRegion] = spec.GetId()
 		}
 	}
 	for i, spec := range dest {
@@ -676,7 +676,7 @@ func PopulateReplicationSpecIds(src, dest []admin.ReplicationSpec) *[]admin.Repl
 			dest[i].SetId(idZone)
 			continue
 		}
-		idProvider, foundProvider := providerRegionToId[asProviderRegion(spec)]
+		idProvider, foundProvider := providerRegionToID[asProviderRegion(spec)]
 		providerUsed := usedIds[idProvider]
 		if foundProvider && !providerUsed {
 			usedIds[idProvider] = true
@@ -685,7 +685,6 @@ func PopulateReplicationSpecIds(src, dest []admin.ReplicationSpec) *[]admin.Repl
 		}
 	}
 	return &dest
-
 }
 
 func asProviderRegion(spec admin.ReplicationSpec) string {

--- a/cfn-resources/cluster/cmd/resource/mappings.go
+++ b/cfn-resources/cluster/cmd/resource/mappings.go
@@ -647,7 +647,7 @@ func setClusterRequest(currentModel *Model) (*admin.AdvancedClusterDescription, 
 	return clusterRequest, nil
 }
 
-func PopulateReplicationSpecIds(src, dest []admin.ReplicationSpec) *[]admin.ReplicationSpec {
+func AddReplicationSpecIds(src, dest []admin.ReplicationSpec) *[]admin.ReplicationSpec {
 	zoneToID := map[string]string{}
 	providerRegionToID := map[string]string{}
 	usedIds := map[string]bool{}

--- a/cfn-resources/cluster/cmd/resource/mappings.go
+++ b/cfn-resources/cluster/cmd/resource/mappings.go
@@ -646,3 +646,52 @@ func setClusterRequest(currentModel *Model) (*admin.AdvancedClusterDescription, 
 	clusterRequest.TerminationProtectionEnabled = currentModel.TerminationProtectionEnabled
 	return clusterRequest, nil
 }
+
+func PopulateReplicationSpecIds(src, dest []admin.ReplicationSpec) *[]admin.ReplicationSpec {
+	zoneToID := map[string]string{}
+	providerRegionToId := map[string]string{}
+	usedIds := map[string]bool{}
+
+	for _, spec := range src {
+		specID := spec.GetId()
+		if specID == "" {
+			continue
+		}
+		if zoneName := spec.GetZoneName(); zoneName != "" {
+			zoneToID[zoneName] = specID
+		}
+		if providerRegion := asProviderRegion(spec); providerRegion != "" {
+			providerRegionToId[providerRegion] = spec.GetId()
+		}
+	}
+	for i, spec := range dest {
+		specID := spec.GetId()
+		if specID != "" {
+			continue
+		}
+		idZone, foundZone := zoneToID[spec.GetZoneName()]
+		zoneUsed := usedIds[idZone]
+		if foundZone && !zoneUsed {
+			usedIds[idZone] = true
+			dest[i].SetId(idZone)
+			continue
+		}
+		idProvider, foundProvider := providerRegionToId[asProviderRegion(spec)]
+		providerUsed := usedIds[idProvider]
+		if foundProvider && !providerUsed {
+			usedIds[idProvider] = true
+			dest[i].SetId(idProvider)
+			continue
+		}
+	}
+	return &dest
+
+}
+
+func asProviderRegion(spec admin.ReplicationSpec) string {
+	configs := spec.GetRegionConfigs()
+	if len(configs) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s-%s", configs[0].GetProviderName(), configs[0].GetRegionName())
+}

--- a/cfn-resources/cluster/cmd/resource/mappings_test.go
+++ b/cfn-resources/cluster/cmd/resource/mappings_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package resource_test
 
 import (

--- a/cfn-resources/cluster/cmd/resource/mappings_test.go
+++ b/cfn-resources/cluster/cmd/resource/mappings_test.go
@@ -1,0 +1,67 @@
+package resource_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/cluster/cmd/resource"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20231115014/admin"
+)
+
+func TestAsProviderRegion(t *testing.T) {
+	testCases := map[string]struct {
+		from        []admin.ReplicationSpec
+		to          []admin.ReplicationSpec
+		expectedIds []string
+	}{
+		"emptyIsOk": {[]admin.ReplicationSpec{}, []admin.ReplicationSpec{}, []string{}},
+		"zoneNameMatch": {
+			[]admin.ReplicationSpec{{Id: util.StringPtr("id1"), ZoneName: util.StringPtr("z1")}},
+			[]admin.ReplicationSpec{{ZoneName: util.StringPtr("z1")}},
+			[]string{"id1"},
+		},
+		"providerRegionMatch": {
+			[]admin.ReplicationSpec{{Id: util.StringPtr("id1"), RegionConfigs: regionConfig("AWS", "US_EAST_1")}},
+			[]admin.ReplicationSpec{{RegionConfigs: regionConfig("AWS", "US_EAST_1")}},
+			[]string{"id1"},
+		},
+		"noMatchRegion": {
+			[]admin.ReplicationSpec{{Id: util.StringPtr("id1"), RegionConfigs: regionConfig("AWS", "US_EAST_1")}},
+			[]admin.ReplicationSpec{{RegionConfigs: regionConfig("AWS", "US_EAST_2")}},
+			[]string{""},
+		},
+		"noMatchZone": {
+			[]admin.ReplicationSpec{{Id: util.StringPtr("id1"), ZoneName: util.StringPtr("z1")}},
+			[]admin.ReplicationSpec{{ZoneName: util.StringPtr("z2")}},
+			[]string{""},
+		},
+		"existingId": {
+			[]admin.ReplicationSpec{{Id: util.StringPtr("id1"), ZoneName: util.StringPtr("z1")}},
+			[]admin.ReplicationSpec{{Id: util.StringPtr("existing"), ZoneName: util.StringPtr("z1")}},
+			[]string{"existing"},
+		},
+		"idMatchedOnlyOnce": {
+			[]admin.ReplicationSpec{{Id: util.StringPtr("id1"), ZoneName: util.StringPtr("z1"), RegionConfigs: regionConfig("AWS", "US_EAST_1")}},
+			[]admin.ReplicationSpec{{ZoneName: util.StringPtr("z1")}, {RegionConfigs: regionConfig("AWS", "US_EAST_1")}},
+			[]string{"id1", ""},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			updated := resource.PopulateReplicationSpecIds(tc.from, tc.to)
+			ids := []string{}
+			for _, spec := range *updated {
+				ids = append(ids, spec.GetId())
+			}
+			assert.Equal(t, tc.expectedIds, ids)
+		})
+	}
+}
+
+func regionConfig(provider, region string) *[]admin.CloudRegionConfig {
+	return &[]admin.CloudRegionConfig{{
+		RegionName:   &region,
+		ProviderName: &provider,
+	}}
+}

--- a/cfn-resources/cluster/cmd/resource/mappings_test.go
+++ b/cfn-resources/cluster/cmd/resource/mappings_test.go
@@ -23,7 +23,7 @@ import (
 	"go.mongodb.org/atlas-sdk/v20231115014/admin"
 )
 
-func TestAsProviderRegion(t *testing.T) {
+func TestAddReplicationSpecIds(t *testing.T) {
 	testCases := map[string]struct {
 		from        []admin.ReplicationSpec
 		to          []admin.ReplicationSpec
@@ -63,7 +63,7 @@ func TestAsProviderRegion(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			updated := resource.PopulateReplicationSpecIds(tc.from, tc.to)
+			updated := resource.AddReplicationSpecIds(tc.from, tc.to)
 			ids := []string{}
 			for _, spec := range *updated {
 				ids = append(ids, spec.GetId())

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -169,7 +169,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if len(adminCluster.GetReplicationSpecs()) > 0 {
 		currentCluster, _, _ := client.AtlasSDK.ClustersApi.GetCluster(context.Background(), *currentModel.ProjectId, *currentModel.Name).Execute()
 		if currentCluster != nil {
-			adminCluster.ReplicationSpecs = PopulateReplicationSpecIds(currentCluster.GetReplicationSpecs(), adminCluster.GetReplicationSpecs())
+			adminCluster.ReplicationSpecs = AddReplicationSpecIds(currentCluster.GetReplicationSpecs(), adminCluster.GetReplicationSpecs())
 		}
 	}
 	if errEvent != nil {
@@ -460,6 +460,7 @@ func updateClusterSettings(currentModel *Model, client *util.MongoDBClient,
 				res), err
 		}
 	}
+
 	jsonStr, _ := json.Marshal(currentModel)
 	_, _ = log.Debugf("Cluster Response --- value: %s ", jsonStr)
 	return *pe, nil

--- a/cfn-resources/cluster/cmd/resource/resource.go
+++ b/cfn-resources/cluster/cmd/resource/resource.go
@@ -460,10 +460,6 @@ func updateClusterSettings(currentModel *Model, client *util.MongoDBClient,
 				res), err
 		}
 	}
-	if len(cluster.GetReplicationSpecs()) > 0 {
-		log.Debug("setting replication specs on model\n")
-		currentModel.ReplicationSpecs = flattenReplicationSpecs(cluster.GetReplicationSpecs())
-	}
 	jsonStr, _ := json.Marshal(currentModel)
 	_, _ = log.Debugf("Cluster Response --- value: %s ", jsonStr)
 	return *pe, nil

--- a/cfn-resources/test/e2e/cluster/cluster.json.template
+++ b/cfn-resources/test/e2e/cluster/cluster.json.template
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "This template creates a cluster and a project in Atlas.",
+  "Description": "This template creates a global GEOSHARDED cluster",
   "Mappings": {},
   "Resources": {
     "Cluster": {
@@ -27,7 +27,7 @@
           "ReadPreference": "secondary",
           "Enabled": "false"
         },
-         "ReplicationSpecs": {{ marshal .ReplicationSpecs }},
+        "ReplicationSpecs": {{ marshal .ReplicationSpecs }},
         "Tags": [
           {
             "Key": "env",

--- a/cfn-resources/test/e2e/cluster/cluster.json.template
+++ b/cfn-resources/test/e2e/cluster/cluster.json.template
@@ -1,0 +1,70 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "This template creates a cluster and a project in Atlas.",
+  "Mappings": {},
+  "Resources": {
+    "Cluster": {
+      "Type": "{{ .ResourceTypeName }}",
+      "Properties": {
+        "Name": "{{ .Name }}",
+        "ProjectId": "{{ .ProjectID }}",
+        "Profile": "{{ .Profile }}",
+        "AdvancedSettings": {
+          "DefaultReadConcern": "available",
+          "DefaultWriteConcern": "1",
+          "JavascriptEnabled": "true",
+          "MinimumEnabledTLSProtocol": "TLS1_2",
+          "NoTableScan": "false",
+          "OplogSizeMB": "2000",
+          "SampleSizeBIConnector": "110",
+          "SampleRefreshIntervalBIConnector": "310"
+        },
+        "BackupEnabled": "false",
+        "ClusterType": "GEOSHARDED",
+        "Paused": "false",
+        "PitEnabled": "false",
+        "BiConnector": {
+          "ReadPreference": "secondary",
+          "Enabled": "false"
+        },
+         "ReplicationSpecs": {{ marshal .ReplicationSpecs }},
+        "Tags": [
+          {
+            "Key": "env",
+            "Value": "development"
+          }
+        ]
+      }
+    }
+  },
+  "Outputs": {
+   "MongoDBAtlasConnectionStrings": {
+      "Description": "Cluster connection strings",
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${AWS::StackName}-ConnectionStrings"
+        }
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "Cluster",
+          "ConnectionStrings.Standard"
+        ]
+      }
+    },
+    "MongoDBAtlasClusterID": {
+      "Description": "Cluster Id",
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${AWS::StackName}-ID"
+        }
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "Cluster",
+          "Id"
+        ]
+      }
+    }
+  }
+}

--- a/cfn-resources/test/e2e/cluster/cluster_test.go
+++ b/cfn-resources/test/e2e/cluster/cluster_test.go
@@ -83,7 +83,7 @@ var (
 	zone2                      = "zone2"
 	replicationSpecZone1Create = replicationSpec(nodeCountCreate, "US_EAST_1", zone1)
 	replicationSpecZone1Update = replicationSpec(nodeCountUpdate, "US_EAST_1", zone1)
-	replicationSpecZone2       = replicationSpec(nodeCountCreate, "EU_WEST_1", zone2)
+	replicationSpecZone2       = replicationSpec(nodeCountUpdate, "EU_WEST_1", zone2)
 	replicationSpecsCreate     = []resource.AdvancedReplicationSpec{replicationSpecZone1Create}
 	replicationSpecsUpdate     = []resource.AdvancedReplicationSpec{replicationSpecZone1Update, replicationSpecZone2}
 )

--- a/cfn-resources/test/e2e/cluster/cluster_test.go
+++ b/cfn-resources/test/e2e/cluster/cluster_test.go
@@ -134,7 +134,7 @@ func testCreateStack(t *testing.T, c *localTestContext) {
 	project, cluster := readFromAtlas(t, c)
 
 	a := assert.New(t)
-	a.Equal(1, project.ClusterCount)
+	a.Equal(int64(1), project.ClusterCount)
 	a.Equal(cluster.GetId(), clusterID)
 	replicationSpecs := cluster.GetReplicationSpecs()
 	checkReplicationSpecs(a, replicationSpecs, nodeCountCreate, 1)
@@ -257,7 +257,7 @@ func getClusterIDFromStack(output *cloudformation.DescribeStacksOutput) string {
 	stackOutputs := output.Stacks[0].Outputs
 	for i := 0; i < len(stackOutputs); i++ {
 		if *aws.String(*stackOutputs[i].OutputKey) == "MongoDBAtlasClusterID" {
-			return *aws.String(*stackOutputs[1].OutputValue)
+			return *aws.String(*stackOutputs[i].OutputValue)
 		}
 	}
 	return ""

--- a/cfn-resources/test/e2e/cluster/cluster_test.go
+++ b/cfn-resources/test/e2e/cluster/cluster_test.go
@@ -1,0 +1,264 @@
+// Copyright 2024 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cluster_test
+
+import (
+	ctx "context"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/cluster/cmd/resource"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/test/e2e/utility"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/atlas-sdk/v20231115014/admin"
+)
+
+type localTestContext struct {
+	cfnClient      *cloudformation.Client
+	atlasClient    *admin.APIClient
+	clusterTmplObj testCluster
+	resourceCtx    utility.ResourceContext
+
+	template            string
+	err                 error
+	replicationIDCreate string
+}
+
+type testCluster struct {
+	ResourceTypeName string
+	Name             string
+	Profile          string
+	ProjectID        string
+	NodeCount        int
+	ReplicationSpecs []resource.AdvancedReplicationSpec
+}
+
+const (
+	resourceTypeName  = "MongoDB::Atlas::Cluster"
+	resourceDirectory = "cluster"
+	cfnTemplatePath   = "cluster.json.template"
+)
+
+func replicationSpec(nodeCount int, region, zoneName string) resource.AdvancedReplicationSpec {
+	return resource.AdvancedReplicationSpec{
+		NumShards: util.IntPtr(1),
+		ZoneName:  &zoneName,
+		AdvancedRegionConfigs: []resource.AdvancedRegionConfig{{
+			RegionName:   &region,
+			Priority:     util.IntPtr(7),
+			ProviderName: util.StringPtr("AWS"),
+			ElectableSpecs: &resource.Specs{
+				EbsVolumeType: util.StringPtr("STANDARD"),
+				InstanceSize:  util.StringPtr("M10"),
+				NodeCount:     &nodeCount,
+			},
+		}},
+	}
+}
+
+var (
+	profile                    = os.Getenv("MONGODB_ATLAS_SECRET_PROFILE")
+	orgID                      = os.Getenv("MONGODB_ATLAS_ORG_ID")
+	e2eRandSuffix              = utility.GetRandNum().String()
+	testProjectName            = "cfn-e2e-cluster" + e2eRandSuffix
+	testClusterName            = "cfn-e2e-cluster" + e2eRandSuffix
+	stackName                  = "stack-cluster-e2e-" + e2eRandSuffix
+	nodeCountCreate            = 3
+	nodeCountUpdate            = 5
+	zone1                      = "zone1"
+	zone2                      = "zone2"
+	replicationSpecZone1Create = replicationSpec(nodeCountCreate, "US_EAST_1", zone1)
+	replicationSpecZone1Update = replicationSpec(nodeCountUpdate, "US_EAST_1", zone1)
+	replicationSpecZone2       = replicationSpec(nodeCountCreate, "EU_WEST_1", zone2)
+	replicationSpecsCreate     = []resource.AdvancedReplicationSpec{replicationSpecZone1Create}
+	replicationSpecsUpdate     = []resource.AdvancedReplicationSpec{replicationSpecZone1Update, replicationSpecZone2}
+)
+
+func TestClusterCFN(t *testing.T) {
+	testCtx := setupSuite(t)
+
+	t.Run("Validate Template", func(t *testing.T) {
+		utility.TestIsTemplateValid(t, testCtx.cfnClient, testCtx.template)
+	})
+
+	t.Run("Create Stack", func(t *testing.T) {
+		testCreateStack(t, testCtx)
+	})
+
+	t.Run("Update Stack", func(t *testing.T) {
+		testUpdateStack(t, testCtx)
+	})
+
+	t.Run("Delete Stack", func(t *testing.T) {
+		testDeleteStack(t, testCtx)
+	})
+}
+
+func setupSuite(t *testing.T) *localTestContext {
+	t.Helper()
+	t.Log("Setting up suite")
+	testCtx := new(localTestContext)
+	testCtx.setUp(t)
+
+	return testCtx
+}
+
+func (c *localTestContext) setUp(t *testing.T) {
+	t.Helper()
+	c.resourceCtx = utility.InitResourceCtx(stackName, e2eRandSuffix, resourceTypeName, resourceDirectory)
+	c.cfnClient, c.atlasClient = utility.NewClients(t)
+	utility.PublishToPrivateRegistry(t, c.resourceCtx)
+	c.setupPrerequisites(t)
+}
+
+func testCreateStack(t *testing.T, c *localTestContext) {
+	t.Helper()
+
+	output := utility.CreateStack(t, c.cfnClient, stackName, c.template)
+	clusterID := getClusterIDFromStack(output)
+
+	project, cluster := readFromAtlas(t, c)
+
+	a := assert.New(t)
+	a.Equal(1, project.ClusterCount)
+	a.Equal(cluster.GetId(), clusterID)
+	replicationSpecs := cluster.GetReplicationSpecs()
+	checkReplicationSpecs(a, replicationSpecs, nodeCountCreate, 1)
+	a.NotEmpty(replicationSpecs[0].GetId())
+	c.replicationIDCreate = replicationSpecs[0].GetId()
+}
+
+func testUpdateStack(t *testing.T, c *localTestContext) {
+	t.Helper()
+
+	c.clusterTmplObj.ReplicationSpecs = replicationSpecsUpdate
+	c.template, c.err = newCFNTemplate(c.clusterTmplObj)
+
+	output := utility.UpdateStack(t, c.cfnClient, stackName, c.template)
+	clusterID := getClusterIDFromStack(output)
+
+	project, cluster := readFromAtlas(t, c)
+
+	a := assert.New(t)
+	a.Equal(int64(1), project.ClusterCount)
+	a.Equal(cluster.GetId(), clusterID)
+	replicationSpecs := cluster.GetReplicationSpecs()
+	checkReplicationSpecs(a, replicationSpecs, nodeCountUpdate, 2)
+	a.NotEmpty(replicationSpecs[0].GetId())
+	a.Equal(replicationSpecs[0].GetId(), c.replicationIDCreate)
+}
+
+func testDeleteStack(t *testing.T, c *localTestContext) {
+	t.Helper()
+
+	utility.DeleteStack(t, c.cfnClient, stackName)
+	_, resp, _ := c.atlasClient.ClustersApi.GetCluster(ctx.Background(), c.clusterTmplObj.ProjectID, c.clusterTmplObj.Name).Execute()
+
+	a := assert.New(t)
+	a.Equal(resp.StatusCode, 404)
+}
+
+func cleanupResources(t *testing.T, c *localTestContext) {
+	t.Helper()
+	utility.DeleteStackForCleanup(t, c.cfnClient, stackName)
+}
+
+func cleanupPrerequisites(t *testing.T, c *localTestContext) {
+	t.Helper()
+	t.Log("Cleaning up prerequisites")
+	if os.Getenv("MONGODB_ATLAS_PROJECT_ID") == "" {
+		utility.DeleteProject(t, c.atlasClient, c.clusterTmplObj.ProjectID)
+	} else {
+		t.Log("skipping project deletion (project managed outside of test)")
+	}
+}
+
+func (c *localTestContext) setupPrerequisites(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() {
+		if os.Getenv("SKIP_CLEANUP") != "" {
+			t.Log("skipping cleanup")
+			return
+		}
+		cleanupPrerequisites(t, c)
+		cleanupResources(t, c)
+	})
+	t.Log("Setting up prerequisites")
+	var projectID string
+	if projectIDEnvVar := os.Getenv("MONGODB_ATLAS_PROJECT_ID"); projectIDEnvVar != "" {
+		t.Logf("using projectID from env var %s", projectIDEnvVar)
+		projectID = projectIDEnvVar
+	} else {
+		projectID = utility.CreateProject(t, c.atlasClient, orgID, testProjectName)
+	}
+
+	c.clusterTmplObj = testCluster{
+		Name:             testClusterName,
+		ProjectID:        projectID,
+		Profile:          profile,
+		NodeCount:        nodeCountCreate,
+		ResourceTypeName: os.Getenv("RESOURCE_TYPE_NAME_FOR_E2E"),
+		ReplicationSpecs: replicationSpecsCreate,
+	}
+
+	// Read required data from resource CFN template
+	c.template, c.err = newCFNTemplate(c.clusterTmplObj)
+	utility.FailNowIfError(t, "Error while reading CFN Template: %v", c.err)
+}
+
+func newCFNTemplate(tmpl testCluster) (string, error) {
+	return utility.ExecuteGoTemplate(cfnTemplatePath, tmpl)
+}
+
+func checkReplicationSpecs(a *assert.Assertions, replicationSpecs []admin.ReplicationSpec, nodeCount, length int) {
+	a.Len(replicationSpecs, length)
+	for i, spec := range replicationSpecs {
+		for _, config := range spec.GetRegionConfigs() {
+			hwSpec := config.GetElectableSpecs()
+			a.Equal(nodeCount, hwSpec.GetNodeCount())
+		}
+		if i == 0 {
+			a.Equal(zone1, spec.GetZoneName())
+		} else if i == 1 {
+			a.Equal(zone2, spec.GetZoneName())
+		}
+	}
+}
+
+func readFromAtlas(t *testing.T, c *localTestContext) (*admin.Group, *admin.AdvancedClusterDescription) {
+	t.Helper()
+
+	ctx := ctx.Background()
+	projectID := c.clusterTmplObj.ProjectID
+	project, getProjectResponse, err := c.atlasClient.ProjectsApi.GetProject(ctx, projectID).Execute()
+	utility.FailNowIfError(t, "Error while retrieving Project from Atlas: %v", err)
+	cluster, getClusterResponse, err := c.atlasClient.ClustersApi.GetCluster(ctx, projectID, c.clusterTmplObj.Name).Execute()
+	utility.FailNowIfError(t, "Err while retrieving Cluster from Atlas: %v", err)
+	assert.Equal(t, 200, getProjectResponse.StatusCode)
+	assert.Equal(t, 200, getClusterResponse.StatusCode)
+	return project, cluster
+}
+
+func getClusterIDFromStack(output *cloudformation.DescribeStacksOutput) string {
+	stackOutputs := output.Stacks[0].Outputs
+	for i := 0; i < len(stackOutputs); i++ {
+		if *aws.String(*stackOutputs[i].OutputKey) == "MongoDBAtlasClusterID" {
+			return *aws.String(*stackOutputs[1].OutputValue)
+		}
+	}
+	return ""
+}

--- a/cfn-resources/test/e2e/cluster/cluster_test.go
+++ b/cfn-resources/test/e2e/cluster/cluster_test.go
@@ -242,11 +242,11 @@ func checkReplicationSpecs(a *assert.Assertions, replicationSpecs []admin.Replic
 func readFromAtlas(t *testing.T, c *localTestContext) (*admin.Group, *admin.AdvancedClusterDescription) {
 	t.Helper()
 
-	ctx := ctx.Background()
+	context := ctx.Background()
 	projectID := c.clusterTmplObj.ProjectID
-	project, getProjectResponse, err := c.atlasClient.ProjectsApi.GetProject(ctx, projectID).Execute()
+	project, getProjectResponse, err := c.atlasClient.ProjectsApi.GetProject(context, projectID).Execute()
 	utility.FailNowIfError(t, "Error while retrieving Project from Atlas: %v", err)
-	cluster, getClusterResponse, err := c.atlasClient.ClustersApi.GetCluster(ctx, projectID, c.clusterTmplObj.Name).Execute()
+	cluster, getClusterResponse, err := c.atlasClient.ClustersApi.GetCluster(context, projectID, c.clusterTmplObj.Name).Execute()
 	utility.FailNowIfError(t, "Err while retrieving Cluster from Atlas: %v", err)
 	assert.Equal(t, 200, getProjectResponse.StatusCode)
 	assert.Equal(t, 200, getClusterResponse.StatusCode)

--- a/cfn-resources/test/e2e/cluster/cluster_test.go
+++ b/cfn-resources/test/e2e/cluster/cluster_test.go
@@ -190,10 +190,6 @@ func cleanupPrerequisites(t *testing.T, c *localTestContext) {
 func (c *localTestContext) setupPrerequisites(t *testing.T) {
 	t.Helper()
 	t.Cleanup(func() {
-		if os.Getenv("SKIP_CLEANUP") != "" {
-			t.Log("skipping cleanup")
-			return
-		}
 		cleanupPrerequisites(t, c)
 		cleanupResources(t, c)
 	})
@@ -215,7 +211,6 @@ func (c *localTestContext) setupPrerequisites(t *testing.T) {
 		ReplicationSpecs: replicationSpecsCreate,
 	}
 
-	// Read required data from resource CFN template
 	c.template, c.err = newCFNTemplate(c.clusterTmplObj)
 	utility.FailNowIfError(t, "Error while reading CFN Template: %v", c.err)
 }

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -344,6 +344,10 @@ func StringToTime(t string) (time.Time, error) {
 	return time.Parse(time.RFC3339Nano, t)
 }
 
+func IntPtr(i int) *int {
+	return &i
+}
+
 func Int64PtrToIntPtr(i64 *int64) *int {
 	if i64 == nil {
 		return nil


### PR DESCRIPTION
## Proposed changes

1. Adds e2e test for cluster
2. Fix: Edits to replication specs for cluster

### Test Summary
1. Create a GEOSHARDED cluster with a single replication spec (zone1) with 3 nodes
2. Update the cluster:
  - Change from 3->5 nodes in zone1
  - Add a new replication spec (zone2) with 5 nodes
3. Assert the replication_id is kept on the 1st replication spec, and a new replication spec is added and both replication specs have 5 nodes

### Fix Summary
The fix reads the current cluster if replication specs are set and "matches" replication IDs.
See the unit tests in  [`mappings_test`](https://github.com/mongodb/mongodbatlas-cloudformation-resources/blob/CLOUDP-256534_replication_id_matching/cfn-resources/cluster/cmd/resource/mappings_test.go#L26) for the matching details.

Note: We couldn't reuse the Terraform implementation since CFN doesn't store the full state of the resource.
It only receives the template used for the update call; this means the replication_spec IDs will never be set on the `prevModel` or `currentModel` (this behavior was "discovered" by trying an initial fix of updating the replication specs of the `currentModel` during create)

### Bug reproduced & fix screenshots

Example of [failing e2e test (Github action before fix committed)](https://github.com/mongodb/mongodbatlas-cloudformation-resources/actions/runs/9683006496/job/26717425799)

Screenshot from CFN:

![image](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/6596097/9f136f7e-cea7-4277-b2c2-1e36db505364)

Example of [passing e2e test (Github action after fix committed)](https://github.com/mongodb/mongodbatlas-cloudformation-resources/actions/runs/9684226069/job/26721481987)

Screenshot from CFN:

![image](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/6596097/c2fe3335-5cfd-4f56-bfa6-9dbe20a75973)

Link to any related issue(s): CLOUDP-256730 and CLOUDP-256534


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [x] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments
contract tests:

![image](https://github.com/mongodb/mongodbatlas-cloudformation-resources/assets/6596097/16f2895b-97b2-4263-aaa7-5a8985966c80)
