### PR TITLE
fix: Removes duplicated `DefaultLimit` in `federated-query-limit` read-only properties

### DIFF
--- a/cfn-resources/federated-query-limit/mongodb-atlas-federatedquerylimit.json
+++ b/cfn-resources/federated-query-limit/mongodb-atlas-federatedquerylimit.json
@@ -64,7 +64,6 @@
   ],
   "readOnlyProperties": [
     "/properties/CurrentUsage",
-    "/properties/DefaultLimit",
     "/properties/LastModifiedDate",
     "/properties/MaximumLimit",
     "/properties/DefaultLimit"


### PR DESCRIPTION
## Proposed changes

Removes duplicated `DefaultLimit` in `federated-query-limit` read-only properties

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

