### PR TITLE
chore: Fixes the pagination for aws cloudformation list-type-versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tools:  ## Install dev tools
 	go install github.com/google/addlicense@latest
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/google/go-licenses@latest
-	go install mvdan.cc/sh/v3/cmd/shfmt@latest
+	go install mvdan.cc/sh/v3/cmd/shfmt@v3.8.0
 	go install github.com/rhysd/actionlint/cmd/actionlint@latest
 	go install go.uber.org/mock/mockgen@latest
 	go install github.com/vektra/mockery/v2@$(MOCKERY_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tools:  ## Install dev tools
 	go install github.com/google/addlicense@latest
 	go install golang.org/x/tools/cmd/goimports@latest
 	go install github.com/google/go-licenses@latest
-	go install mvdan.cc/sh/v3/cmd/shfmt@v3.8.0
+	go install mvdan.cc/sh/v3/cmd/shfmt@v3.8.0 ## locking version until we have upgraded to go 1.22
 	go install github.com/rhysd/actionlint/cmd/actionlint@latest
 	go install go.uber.org/mock/mockgen@latest
 	go install github.com/vektra/mockery/v2@$(MOCKERY_VERSION)


### PR DESCRIPTION
## Proposed changes

Fixes the pagination for aws cloudformation list-type-versions

Link to any related issue(s): CLOUDP-268623


### [Successful run to test fix](https://github.com/mongodb/mongodbatlas-cloudformation-resources/actions/runs/10456544477/job/28954082064)


### [Failed run for `master`](https://github.com/mongodb/mongodbatlas-cloudformation-resources/actions/runs/10450481102/job/28943242393)
Relevant failing logs from s3 (similar execution role is used in all the 3 failed attempts):

```
[2024-08-19T09:12:43Z] DEBUG    - Running test: Namespace(version=False, subparser_name='test', command=<function test at 0x7fcd23c795e0>, verbose=0, endpoint='<https://lambda.ap-northeast-2.amazonaws.com>', function_name='MongoDB-Atlas-Cluster711489243244-Handler-1u0hypumvwcoc', region='ap-northeast-2', profile=None, role_arn='arn:aws:iam::711489243244:role/mongodb-atlas-cluster-role-stack-ExecutionRole-Ae24TDEYnNlX', cloudformation_endpoint_url=None, enforce_timeout='240', log_group_name=None, log_role_arn=None, passed_to_pytest=[], docker_image=None, typeconfig=None, source_account='711489243244', source_arn='arn:aws:cloudformation:ap-northeast-2:711489243244:type/resource/MongoDB-Atlas-Cluster/00000036')
Getting session token resulted in unknown ClientError. Could not assume specified role 'arn:aws:iam::711489243244:role/mongodb-atlas-cluster-role-stack-ExecutionRole-Ae24TDEYnNlX'.
```

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

