### PR TITLE
chore: Updates exclude-rules in Go linter

### DIFF
--- a/cfn-resources/.golangci.yml
+++ b/cfn-resources/.golangci.yml
@@ -123,13 +123,6 @@ linters:
 issues:
   exclude:
     - declaration of ".*" shadows declaration at line .*
-  exclude-rules:
-    - linters:
-        - staticcheck
-      text: "SA1019:" # d.GetOkExists is deprecated: usage is discouraged due to undefined behaviors and may be removed in a future version of the SDK
-    - linters:
-        - gocritic
-      text: "^hugeParam: req is heavy"
 run:
   timeout: 10m
   tests: true


### PR DESCRIPTION
## Proposed changes

Updates exclude-rules in Go linter.

Follow-up PR from this comment https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/1144#discussion_r1743736922

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

