### PR TITLE
chore: Uses QA environment when publishing resource-policy

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,6 +30,7 @@ jobs:
       MONGODB_ATLAS_ORG_ID: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_ORG_ID_DEV || github.event.inputs.resourceName=='resource-policy' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_ORG_ID_FOR_FEDERATION || secrets.ATLAS_ORG_ID_PUBLISHING }}
       MONGODB_ATLAS_PUBLIC_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PUBLIC_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PUBLIC_KEY_FOR_FEDERATION || secrets.ATLAS_PUBLIC_KEY_PUBLISHING }}
       MONGODB_ATLAS_PRIVATE_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PRIVATE_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PRIVATE_KEY_FOR_FEDERATION || secrets.ATLAS_PRIVATE_KEY_PUBLISHING }}
+      MONGODB_ATLAS_PROFILE: ${{ github.event.inputs.resourceName=='resource-policy' && 'qa-cloud-profile' || 'default' }}
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(github.event.inputs.maxParallelRegions) }}
@@ -74,7 +75,7 @@ jobs:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_PUBLISHING}}
           MONGODB_ATLAS_ORG_OWNER_ID: ${{ secrets.ATLAS_ORG_OWNER_ID_PUBLISHING }}
           ATLAS_FEDERATED_SETTINGS_ID: ${{ secrets.ATLAS_FEDERATED_SETTINGS_ID_PUBLISHING }}
-          MONGODB_ATLAS_PROFILE: cfn-cloud-dev-github-action
+          MONGODB_ATLAS_PROFILE: ${{ env.MONGODB_ATLAS_PROFILE }}
 
           # LDAP config
           LDAP_HOST_NAME: ${{ secrets.LDAP_HOST_NAME_PUBLISHING }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
       MONGODB_ATLAS_ORG_ID: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_ORG_ID_DEV || github.event.inputs.resourceName=='resource-policy' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_ORG_ID_FOR_FEDERATION || secrets.ATLAS_ORG_ID_PUBLISHING }}
       MONGODB_ATLAS_PUBLIC_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PUBLIC_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PUBLIC_KEY_FOR_FEDERATION || secrets.ATLAS_PUBLIC_KEY_PUBLISHING }}
       MONGODB_ATLAS_PRIVATE_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PRIVATE_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PRIVATE_KEY_FOR_FEDERATION || secrets.ATLAS_PRIVATE_KEY_PUBLISHING }}
-      MONGODB_ATLAS_PROFILE: ${{ github.event.inputs.resourceName=='resource-policy' && 'qa-cloud-profile' || 'default' }}
+      PUBLISH_ONLY: ${{ github.event.inputs.resourceName=='resource-policy' && 'true' || 'false' }}
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(github.event.inputs.maxParallelRegions) }}
@@ -75,7 +75,7 @@ jobs:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_PUBLISHING}}
           MONGODB_ATLAS_ORG_OWNER_ID: ${{ secrets.ATLAS_ORG_OWNER_ID_PUBLISHING }}
           ATLAS_FEDERATED_SETTINGS_ID: ${{ secrets.ATLAS_FEDERATED_SETTINGS_ID_PUBLISHING }}
-          MONGODB_ATLAS_PROFILE: ${{ env.MONGODB_ATLAS_PROFILE }}
+          PUBLISH_ONLY: ${{ env.PUBLISH_ONLY}}
 
           # LDAP config
           LDAP_HOST_NAME: ${{ secrets.LDAP_HOST_NAME_PUBLISHING }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -74,6 +74,7 @@ jobs:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_PUBLISHING}}
           MONGODB_ATLAS_ORG_OWNER_ID: ${{ secrets.ATLAS_ORG_OWNER_ID_PUBLISHING }}
           ATLAS_FEDERATED_SETTINGS_ID: ${{ secrets.ATLAS_FEDERATED_SETTINGS_ID_PUBLISHING }}
+          MONGODB_ATLAS_PROFILE: cfn-cloud-dev-github-action
 
           # LDAP config
           LDAP_HOST_NAME: ${{ secrets.LDAP_HOST_NAME_PUBLISHING }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,6 @@ jobs:
       MONGODB_ATLAS_ORG_ID: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_ORG_ID_DEV || github.event.inputs.resourceName=='resource-policy' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_ORG_ID_FOR_FEDERATION || secrets.ATLAS_ORG_ID_PUBLISHING }}
       MONGODB_ATLAS_PUBLIC_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PUBLIC_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PUBLIC_KEY_FOR_FEDERATION || secrets.ATLAS_PUBLIC_KEY_PUBLISHING }}
       MONGODB_ATLAS_PRIVATE_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PRIVATE_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PRIVATE_KEY_FOR_FEDERATION || secrets.ATLAS_PRIVATE_KEY_PUBLISHING }}
-      PUBLISH_ONLY: ${{ github.event.inputs.resourceName=='resource-policy' && 'true' || 'false' }}
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(github.event.inputs.maxParallelRegions) }}
@@ -75,7 +74,6 @@ jobs:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_PUBLISHING}}
           MONGODB_ATLAS_ORG_OWNER_ID: ${{ secrets.ATLAS_ORG_OWNER_ID_PUBLISHING }}
           ATLAS_FEDERATED_SETTINGS_ID: ${{ secrets.ATLAS_FEDERATED_SETTINGS_ID_PUBLISHING }}
-          PUBLISH_ONLY: ${{ env.PUBLISH_ONLY}}
 
           # LDAP config
           LDAP_HOST_NAME: ${{ secrets.LDAP_HOST_NAME_PUBLISHING }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
       MONGODB_ATLAS_ORG_ID: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_ORG_ID_DEV || github.event.inputs.resourceName=='resource-policy' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_ORG_ID_FOR_FEDERATION || secrets.ATLAS_ORG_ID_PUBLISHING }}
       MONGODB_ATLAS_PUBLIC_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PUBLIC_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PUBLIC_KEY_FOR_FEDERATION || secrets.ATLAS_PUBLIC_KEY_PUBLISHING }}
       MONGODB_ATLAS_PRIVATE_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PRIVATE_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PRIVATE_KEY_FOR_FEDERATION || secrets.ATLAS_PRIVATE_KEY_PUBLISHING }}
-      MONGODB_ATLAS_PROFILE: ${{ github.event.inputs.resourceName=='resource-policy' && 'qa-cloud-profile' || 'default' }}
+      MONGODB_ATLAS_PROFILE: ${{ github.event.inputs.resourceName=='resource-policy' && 'qa-resource-policy-cloud-profile' || 'default' }}
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(github.event.inputs.maxParallelRegions) }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,6 +30,7 @@ jobs:
       MONGODB_ATLAS_ORG_ID: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_ORG_ID_DEV || github.event.inputs.resourceName=='resource-policy' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_ORG_ID_FOR_FEDERATION || secrets.ATLAS_ORG_ID_PUBLISHING }}
       MONGODB_ATLAS_PUBLIC_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PUBLIC_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PUBLIC_KEY_FOR_FEDERATION || secrets.ATLAS_PUBLIC_KEY_PUBLISHING }}
       MONGODB_ATLAS_PRIVATE_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PRIVATE_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PRIVATE_KEY_FOR_FEDERATION || secrets.ATLAS_PRIVATE_KEY_PUBLISHING }}
+      MONGODB_ATLAS_PROFILE: ${{ github.event.inputs.resourceName=='resource-policy' && 'qa-cloud-profile' || 'default' }}
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(github.event.inputs.maxParallelRegions) }}
@@ -74,6 +75,7 @@ jobs:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID_PUBLISHING}}
           MONGODB_ATLAS_ORG_OWNER_ID: ${{ secrets.ATLAS_ORG_OWNER_ID_PUBLISHING }}
           ATLAS_FEDERATED_SETTINGS_ID: ${{ secrets.ATLAS_FEDERATED_SETTINGS_ID_PUBLISHING }}
+          MONGODB_ATLAS_PROFILE: ${{ env.MONGODB_ATLAS_PROFILE }}
 
           # LDAP config
           LDAP_HOST_NAME: ${{ secrets.LDAP_HOST_NAME_PUBLISHING }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,12 +24,12 @@ on:
 jobs:
   publish:
     env: # env vars defined here can be referenced in env vars inside the steps
-      MONGODB_ATLAS_BASE_URL: 'https://cloud.mongodb.com/'
+      MONGODB_ATLAS_BASE_URL: ${{ github.event.inputs.resourceName=='resource-policy' && 'https://cloud-qa.mongodb.com/' || 'https://cloud.mongodb.com/' }}
       MONGODB_ATLAS_OUTPUT: 'json'
       # some resources need specific Atlas credentials and orgs
-      MONGODB_ATLAS_ORG_ID: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_ORG_ID_DEV || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_ORG_ID_FOR_FEDERATION || secrets.ATLAS_ORG_ID_PUBLISHING }}
-      MONGODB_ATLAS_PUBLIC_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PUBLIC_KEY_DEV || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PUBLIC_KEY_FOR_FEDERATION || secrets.ATLAS_PUBLIC_KEY_PUBLISHING }}
-      MONGODB_ATLAS_PRIVATE_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PRIVATE_KEY_DEV || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PRIVATE_KEY_FOR_FEDERATION || secrets.ATLAS_PRIVATE_KEY_PUBLISHING }}
+      MONGODB_ATLAS_ORG_ID: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_ORG_ID_DEV || github.event.inputs.resourceName=='resource-policy' && vars.MONGODB_ATLAS_RP_ORG_ID_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_ORG_ID_FOR_FEDERATION || secrets.ATLAS_ORG_ID_PUBLISHING }}
+      MONGODB_ATLAS_PUBLIC_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PUBLIC_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PUBLIC_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PUBLIC_KEY_FOR_FEDERATION || secrets.ATLAS_PUBLIC_KEY_PUBLISHING }}
+      MONGODB_ATLAS_PRIVATE_KEY: ${{ github.event.inputs.resourceName=='organization' && secrets.ATLAS_PRIVATE_KEY_DEV || github.event.inputs.resourceName=='resource-policy' && secrets.MONGODB_ATLAS_RP_PRIVATE_KEY_QA || github.event.inputs.resourceName=='federated-settings-org-role-mapping' && secrets.ATLAS_PRIVATE_KEY_FOR_FEDERATION || secrets.ATLAS_PRIVATE_KEY_PUBLISHING }}
     strategy:
       fail-fast: false
       max-parallel: ${{ fromJSON(github.event.inputs.maxParallelRegions) }}

--- a/cfn-resources/cfn-publishing-helper.sh
+++ b/cfn-resources/cfn-publishing-helper.sh
@@ -11,7 +11,6 @@
 # There are some options.
 #
 # TEST_ONLY=true|false
-# PUBLISH_ONLY=true|false
 # LOG_LEVEL=logrus valid string loglevel
 #
 # Example with DEBUG logging enabled by default for set of resources:
@@ -54,10 +53,6 @@ fi
 for resource in ${resources}; do
 	echo "Working on resource:${resource}"
 	[[ "${_DRY_RUN}" == "true" ]] && echo "[dry-run] would have run make on:${resource}" && continue
-	if [[ "${_PUBLISH_ONLY}" == "true" ]]; then
-		echo "_PUBLISH_ONLY was true, not running 'cfn test' in cloud"
-		continue
-	fi
 
 	cd "${resource}"
 	echo "resource: ${resource}"

--- a/cfn-resources/cfn-publishing-helper.sh
+++ b/cfn-resources/cfn-publishing-helper.sh
@@ -70,7 +70,7 @@ for resource in ${resources}; do
 	echo "res_type=${res_type}"
 	version=$(aws cloudformation list-types --output=json | jq --arg typeName "${res_type}" '.TypeSummaries[] | select(.TypeName==$typeName)' | jq -r '.DefaultVersionId')
 	echo "version from cfn-publishing-helper=${version}"
-	arn=$(aws cloudformation test-type --profile "${profile}" --type RESOURCE --type-name "${res_type}" --log-delivery-bucket "${_CFN_TEST_LOG_BUCKET}" --version-id "${version}" --profile "${profile}" | jq -r '.TypeVersionArn')
+	arn=$(aws cloudformation test-type --profile "${profile}" --type RESOURCE --type-name "${res_type}" --log-delivery-bucket "${_CFN_TEST_LOG_BUCKET}" --version-id "${version}" | jq -r '.TypeVersionArn')
 	echo "arn from cfn-publishing-helper=${arn}"
 
 	echo "********** Initiated test-type command ***********"

--- a/cfn-resources/cfn-publishing-helper.sh
+++ b/cfn-resources/cfn-publishing-helper.sh
@@ -26,7 +26,6 @@ set -e
 # shellcheck source=/dev/null
 . ./cfn-publishing-helper.config
 env | grep CFN_PUBLISH_
-echo $MONGODB_ATLAS_PROFILE
 
 _DRY_RUN=${DRY_RUN:-false}
 # shellcheck disable=SC2034
@@ -37,7 +36,6 @@ _PUBLISH_ONLY=${PUBLISH_ONLY:-false}
 _DEFAULT_LOG_LEVEL=${LOG_LEVEL:-info}
 _CFN_TEST_LOG_BUCKET=${CFN_TEST_LOG_BUCKET:-mongodb-cfn-testing}
 version="${2:-00000001}"
-profile=$MONGODB_ATLAS_PROFILE
 
 #echo " ******************** version : ${version}"
 [[ "${_DRY_RUN}" == "true" ]] && echo "*************** DRY_RUN mode enabled **************"
@@ -70,7 +68,7 @@ for resource in ${resources}; do
 	echo "res_type=${res_type}"
 	version=$(aws cloudformation list-types --output=json | jq --arg typeName "${res_type}" '.TypeSummaries[] | select(.TypeName==$typeName)' | jq -r '.DefaultVersionId')
 	echo "version from cfn-publishing-helper=${version}"
-	arn=$(aws cloudformation test-type --profile "${profile}" --type RESOURCE --type-name "${res_type}" --log-delivery-bucket "${_CFN_TEST_LOG_BUCKET}" --version-id "${version}" | jq -r '.TypeVersionArn')
+	arn=$(aws cloudformation test-type --type RESOURCE --type-name "${res_type}" --log-delivery-bucket "${_CFN_TEST_LOG_BUCKET}" --version-id "${version}" | jq -r '.TypeVersionArn')
 	echo "arn from cfn-publishing-helper=${arn}"
 
 	echo "********** Initiated test-type command ***********"
@@ -82,7 +80,7 @@ for resource in ${resources}; do
 	# sometime the status is not_tested after triggering the test, so keeping delay
 	status=$(echo "${dt}" | jq -r '.TypeTestsStatus')
 	if [[ "$status" == "NOT_TESTED" ]]; then
-		test_type_resp=$(aws cloudformation test-type --profile "${profile}" --type RESOURCE --type-name "${res_type}" --log-delivery-bucket "${_CFN_TEST_LOG_BUCKET}" --version-id "${version}")
+		test_type_resp=$(aws cloudformation test-type --type RESOURCE --type-name "${res_type}" --log-delivery-bucket "${_CFN_TEST_LOG_BUCKET}" --version-id "${version}")
 		arn=$(echo "${test_type_resp}" | jq -r '.TypeVersionArn')
 		sleep 60
 	fi


### PR DESCRIPTION


## Proposed changes

Uses QA environmnet when publishing resource-policy


Link to any related issue(s): CLOUDP-272615


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

