### PR TITLE
chore: Adds DebugClient config option with override of `MONGODB_ATLAS_DEBUG` env-var

### DIFF
--- a/cfn-resources/profile/profile.go
+++ b/cfn-resources/profile/profile.go
@@ -30,9 +30,10 @@ const (
 )
 
 type Profile struct {
-	PublicKey  string `json:"PublicKey"`
-	PrivateKey string `json:"PrivateKey"`
-	BaseURL    string `json:"BaseUrl,omitempty"`
+	DebugClient *bool  `json:"DebugClient,omitempty"`
+	PublicKey   string `json:"PublicKey"`
+	PrivateKey  string `json:"PrivateKey"`
+	BaseURL     string `json:"BaseUrl,omitempty"`
 }
 
 func NewProfile(req *handler.Request, profileName *string, prefixRequired bool) (*Profile, error) {
@@ -85,6 +86,16 @@ func (p *Profile) NewPrivateKey() string {
 
 func (p *Profile) AreKeysAvailable() bool {
 	return p.NewPublicKey() == "" || p.PrivateKey == ""
+}
+
+func (p *Profile) UseDebug() bool {
+	if debug := os.Getenv("MONGODB_ATLAS_DEBUG"); debug != "" {
+		return debug == "true"
+	}
+	if p.DebugClient != nil {
+		return *p.DebugClient
+	}
+	return false
 }
 
 func SecretNameWithPrefix(name string) string {

--- a/cfn-resources/profile/profile_test.go
+++ b/cfn-resources/profile/profile_test.go
@@ -1,0 +1,20 @@
+package profile_test
+
+import (
+	"testing"
+
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_UseDebug(t *testing.T) {
+	profileFalse := profile.Profile{}
+	assert.False(t, profileFalse.UseDebug())
+	t.Setenv("MONGODB_ATLAS_DEBUG", "true")
+	assert.True(t, profileFalse.UseDebug())
+	t.Setenv("MONGODB_ATLAS_DEBUG", "")
+	assert.False(t, profileFalse.UseDebug())
+	trueBool := true
+	profileTrue := profile.Profile{DebugClient: &trueBool}
+	assert.True(t, profileTrue.UseDebug())
+}

--- a/cfn-resources/test/e2e/utility/atlas_helper.go
+++ b/cfn-resources/test/e2e/utility/atlas_helper.go
@@ -54,7 +54,7 @@ func NewMongoDBClient() (atlasClient *admin.APIClient, err error) {
 	t := digest.NewTransport(atlasEnv.PublicKey, atlasEnv.PrivateKey)
 	client, _ := t.Client()
 
-	c := util.Config{}
+	c := util.Config{DebugClient: true}
 	if baseURL := atlasEnv.BaseURL; baseURL != "" {
 		c.BaseURL = baseURL
 	}

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -64,6 +64,7 @@ type Config struct {
 	PrivateKey   string
 	BaseURL      string
 	RealmBaseURL string
+	DebugClient  bool
 }
 
 type AssumeRole struct {
@@ -154,7 +155,7 @@ func newAtlasV2Client(req *handler.Request, profileName *string, profileNamePref
 			HandlerErrorCode: cloudformation.HandlerErrorCodeInvalidRequest}
 	}
 
-	c := Config{BaseURL: prof.BaseURL}
+	c := Config{BaseURL: prof.BaseURL, DebugClient: prof.UseDebug()}
 
 	// new V2 version 20231115002 instance
 	sdk20231115002Client, err := c.NewSDKv20231115002Client(client)
@@ -198,7 +199,7 @@ func (c *Config) NewSDKv20231115002Client(client *http.Client) (*admin2023111500
 		admin20231115002.UseHTTPClient(client),
 		admin20231115002.UseUserAgent(userAgent),
 		admin20231115002.UseBaseURL(c.BaseURL),
-		admin20231115002.UseDebug(false)}
+		admin20231115002.UseDebug(c.DebugClient)}
 
 	sdkV2, err := admin20231115002.NewClient(opts...)
 	if err != nil {
@@ -213,7 +214,7 @@ func (c *Config) NewSDKv20231115014Client(client *http.Client) (*admin2023111501
 		admin20231115014.UseHTTPClient(client),
 		admin20231115014.UseUserAgent(userAgent),
 		admin20231115014.UseBaseURL(c.BaseURL),
-		admin20231115014.UseDebug(false)}
+		admin20231115014.UseDebug(c.DebugClient)}
 
 	sdkV2, err := admin20231115014.NewClient(opts...)
 	if err != nil {
@@ -228,7 +229,7 @@ func (c *Config) NewSDKV2LatestClient(client *http.Client) (*admin.APIClient, er
 		admin.UseHTTPClient(client),
 		admin.UseUserAgent(userAgent),
 		admin.UseBaseURL(c.BaseURL),
-		admin.UseDebug(false)}
+		admin.UseDebug(c.DebugClient)}
 
 	// Initialize the MongoDB Versioned Atlas Client.
 	sdkV2, err := admin.NewClient(opts...)


### PR DESCRIPTION
## Proposed changes

Adds DebugClient config option with override of `MONGODB_ATLAS_DEBUG` env-var

Link to any related issue(s): CLOUDP-269862


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

Example when the `DebugClient` is not set:
```
Mounting /Users/espen.albert/code/go/src/github.com/mongodb/mongodbatlas-cloudformation-resources/cfn-resources/resource-policy/bin as /var/task:ro,delegated, inside runtime container
START RequestId: dd94a5d8-608f-4d92-a5a9-b7f6edfc23b3 Version: $LATEST
2024/09/24 09:38:52 Handler starting
2024/09/24 09:38:52 Handler received the CREATE action
2024/09/24 09:38:54 Received event: SUCCESS
Message: Create Completed
END RequestId: f6015909-915c-4c67-9b92-ce9461a7c874
REPORT RequestId: f6015909-915c-4c67-9b92-ce9461a7c874	Init Duration: 0.62 ms	Duration: 3992.87 ms	Billed Duration: 3993 ms	Memory Size: 256 MB	Max Memory Used: 256 MB

2024-09-24 10:38:54 127.0.0.1 - - [24/Sep/2024 10:38:54] "POST /2015-03-31/functions/TestEntrypoint/invocations HTTP/1.1" 200 -
Invoking bootstrap (provided.al2)
Requested to skip pulling images ...
```

Example with `DebugClient`
```
Mounting /Users/espen.albert/code/go/src/github.com/mongodb/mongodbatlas-cloudformation-resources/cfn-resources/resource-policy/bin as /var/task:ro,delegated, inside runtime container
START RequestId: 0e1e5f46-ed4f-437a-95be-c4e7c231ad90 Version: $LATEST
2024/09/24 09:30:27 Handler starting
2024/09/24 09:30:27 Handler received the CREATE action
2024/09/24 09:30:28
POST /api/atlas/v2/orgs/65def6ce0f722a1507105aa5/resourcePolicies HTTP/1.1

Host: cloud-dev.mongodb.com

User-Agent: mongodbatlas-cloudformation-resources/c4c5f6b1ce04d3169ef2a81feb4f46d855ff501b (linux;amd64)

Content-Length: 219

Accept: application/vnd.atlas.2024-08-05+json

Content-Type: application/vnd.atlas.2024-08-05+json

Accept-Encoding: gzip



{"name":"ct-resource-policy-4426","policies":[{"body":"forbid (principal,action == cloud::Action::\"cluster.createEdit\",resource) when {context.cluster.cloudProviders.containsAny([cloud::cloudProvider::\"aws\"])};"}]}

2024/09/24 09:30:29
HTTP/2.0 201 Created

Content-Type: application/vnd.atlas.2024-08-05+json;charset=utf-8

Date: Tue, 24 Sep 2024 09:30:28 GMT

Referrer-Policy: strict-origin-when-cross-origin

Server: mdbws

Strict-Transport-Security: max-age=31536000; includeSubdomains;

Vary: Accept-Encoding

X-Content-Type-Options: nosniff

X-Envoy-Upstream-Service-Time: 47

X-Frame-Options: DENY

X-Java-Method: ApiAtlasResourcePolicyResource::createResourcePolicy

X-Java-Version: 17.0.12+7

X-Mongodb-Service-Version: gitHash=85e4e5c580857336dd65f84db8326748bd24b3c7; versionString=master

X-Permitted-Cross-Domain-Policies: none



{"createdByUser":{"id":"65def6f00f722a1507105ad8","name":"mvccpeou"},"createdDate":"2024-09-24T09:30:29Z","id":"66f286b5d5c87b5f1a89cb52","lastUpdatedByUser":{"id":"65def6f00f722a1507105ad8","name":"mvccpeou"},"lastUpdatedDate":"2024-09-24T09:30:29Z","name":"ct-resource-policy-4426","orgId":"65def6ce0f722a1507105aa5","policies":[{"body":"forbid (principal,action == cloud::Action::\"cluster.createEdit\",resource) when {context.cluster.cloudProviders.containsAny([cloud::cloudProvider::\"aws\"])};","id":"66f286b5d5c87b5f1a89cb51"}],"version":"v1"}
2024/09/24 09:30:29 Received event: SUCCESS
Message: Create Completed
END RequestId: 673c1f2d-5608-47e6-8ab2-f7777d4422ad
REPORT RequestId: 673c1f2d-5608-47e6-8ab2-f7777d4422ad	Init Duration: 1.06 ms	Duration: 3446.36 ms	Billed Duration: 3447 ms	Memory Size: 256 MB	Max Memory Used: 256 MB

2024-09-24 10:30:29 127.0.0.1 - - [24/Sep/2024 10:30:29] "POST /2015-03-31/functions/TestEntrypoint/invocations HTTP/1.1" 200 -
```