### PR TITLE
fix: resource-policy schema, mark required attributes

### DIFF
--- a/cfn-resources/resource-policy/docs/README.md
+++ b/cfn-resources/resource-policy/docs/README.md
@@ -58,7 +58,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 Human-readable label that describes the atlas resource policy.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -68,7 +68,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 Unique 24-hexadecimal digit string that identifies the organization that contains your projects. Use the [/orgs](#tag/Organizations/operation/listOrganizations) endpoint to retrieve all organizations to which the authenticated user has access.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 
@@ -84,7 +84,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 List of policies that make up the atlas resource policy.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: List of <a href="apiatlaspolicy.md">ApiAtlasPolicy</a>
 

--- a/cfn-resources/resource-policy/docs/apiatlaspolicy.md
+++ b/cfn-resources/resource-policy/docs/apiatlaspolicy.md
@@ -26,7 +26,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 
 A string that defines the permissions for the policy. The syntax used is the Cedar Policy language.
 
-_Required_: No
+_Required_: Yes
 
 _Type_: String
 

--- a/cfn-resources/resource-policy/mongodb-atlas-resourcepolicy.json
+++ b/cfn-resources/resource-policy/mongodb-atlas-resourcepolicy.json
@@ -15,7 +15,10 @@
           "minLength": 24
         }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": [
+        "Body"
+      ]
     },
     "ApiAtlasPolicyCreate": {
       "type": "object",
@@ -137,5 +140,10 @@
     "/properties/OrgId",
     "/properties/Profile"
   ],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "required": [
+    "Name",
+    "OrgId",
+    "Policies"
+  ]
 }


### PR DESCRIPTION
## Proposed changes

resource-policy schema, mark required attributes

Link to any related issue(s): CLOUDP-275212

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

