### PR TITLE
chore: Removes `ProjectOwnerId` from read only properties in `Project`

### DIFF
--- a/cfn-resources/project/docs/README.md
+++ b/cfn-resources/project/docs/README.md
@@ -14,6 +14,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Properties" : {
         "<a href="#name" title="Name">Name</a>" : <i>String</i>,
         "<a href="#orgid" title="OrgId">OrgId</a>" : <i>String</i>,
+        "<a href="#projectownerid" title="ProjectOwnerId">ProjectOwnerId</a>" : <i>String</i>,
         "<a href="#withdefaultalertssettings" title="WithDefaultAlertsSettings">WithDefaultAlertsSettings</a>" : <i>Boolean</i>,
         "<a href="#projectsettings" title="ProjectSettings">ProjectSettings</a>" : <i><a href="projectsettings.md">projectSettings</a></i>,
         "<a href="#profile" title="Profile">Profile</a>" : <i>String</i>,
@@ -32,6 +33,7 @@ Type: MongoDB::Atlas::Project
 Properties:
     <a href="#name" title="Name">Name</a>: <i>String</i>
     <a href="#orgid" title="OrgId">OrgId</a>: <i>String</i>
+    <a href="#projectownerid" title="ProjectOwnerId">ProjectOwnerId</a>: <i>String</i>
     <a href="#withdefaultalertssettings" title="WithDefaultAlertsSettings">WithDefaultAlertsSettings</a>: <i>Boolean</i>
     <a href="#projectsettings" title="ProjectSettings">ProjectSettings</a>: <i><a href="projectsettings.md">projectSettings</a></i>
     <a href="#profile" title="Profile">Profile</a>: <i>String</i>
@@ -60,6 +62,16 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 Unique identifier of the organization within which to create the project.
 
 _Required_: Yes
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### ProjectOwnerId
+
+Unique identifier of the organization within which to create the project.
+
+_Required_: No
 
 _Type_: String
 
@@ -148,10 +160,6 @@ The unique identifier of the project.
 #### Created
 
 The ISO-8601-formatted timestamp of when Atlas created the project.
-
-#### ProjectOwnerId
-
-Unique identifier of the organization within which to create the project.
 
 #### ClusterCount
 

--- a/cfn-resources/project/mongodb-atlas-project.json
+++ b/cfn-resources/project/mongodb-atlas-project.json
@@ -168,7 +168,6 @@
   "readOnlyProperties": [
     "/properties/Id",
     "/properties/Created",
-    "/properties/ProjectOwnerId",
     "/properties/ClusterCount"
   ],
   "primaryIdentifier": [


### PR DESCRIPTION

## Proposed changes

Removes `ProjectOwnerId` from read only properties in `Project`

Link to any related issue(s): CLOUDP-274173

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

