### PR TITLE
fix: Avoids runtime error: invalid memory address or nil pointer dereference when type!=DatabaseTrigger

### DIFF
--- a/cfn-resources/trigger/cmd/resource/resource.go
+++ b/cfn-resources/trigger/cmd/resource/resource.go
@@ -229,28 +229,26 @@ func newEventTrigger(model *Model) (*realm.EventTriggerRequest, error) {
 		conf.Database = *model.DatabaseTrigger.Database
 	}
 	dTrigger := model.DatabaseTrigger
-
-	if dTrigger.Match != nil {
-		jsonData := []byte(*dTrigger.Match)
-		// convert the JSON string to a map
-		var m interface{}
-		if err := json.Unmarshal(jsonData, &m); err != nil {
-			return nil, errors.New("error unmarshalling Match field - " + err.Error())
-		}
-		conf.Match = m
-	}
-
-	if dTrigger.Project != nil {
-		jsonData := []byte(*dTrigger.Project)
-		// convert the JSON string to a map
-		var m interface{}
-		if err := json.Unmarshal(jsonData, &m); err != nil {
-			return nil, errors.New("error unmarshalling Project field - " + err.Error())
-		}
-		conf.Project = m
-	}
-
 	if dTrigger != nil {
+		if dTrigger.Match != nil {
+			jsonData := []byte(*dTrigger.Match)
+			// convert the JSON string to a map
+			var m interface{}
+			if err := json.Unmarshal(jsonData, &m); err != nil {
+				return nil, errors.New("error unmarshalling Match field - " + err.Error())
+			}
+			conf.Match = m
+		}
+
+		if dTrigger.Project != nil {
+			jsonData := []byte(*dTrigger.Project)
+			// convert the JSON string to a map
+			var m interface{}
+			if err := json.Unmarshal(jsonData, &m); err != nil {
+				return nil, errors.New("error unmarshalling Project field - " + err.Error())
+			}
+			conf.Project = m
+		}
 		conf.Collection = aws.StringValue(dTrigger.Collection)
 		conf.ServiceID = aws.StringValue(dTrigger.ServiceId)
 		conf.OperationTypes = dTrigger.OperationTypes


### PR DESCRIPTION
## Proposed changes

Avoids runtime error: invalid memory address or nil pointer dereference when type!=DatabaseTrigger

Link to any related issue(s): CLOUDP-282800


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

