### PR TITLE
fix: Sets scopes in Read to support Scope updates

### DIFF
--- a/cfn-resources/database-user/cmd/resource/resource.go
+++ b/cfn-resources/database-user/cmd/resource/resource.go
@@ -104,19 +104,12 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
 
-	currentModel.DatabaseName = &databaseUser.DatabaseName
-
-	if currentModel.LdapAuthType != nil {
-		currentModel.LdapAuthType = databaseUser.LdapAuthType
-	}
-	if currentModel.AWSIAMType != nil {
-		currentModel.AWSIAMType = databaseUser.AwsIAMType
-	}
-	if currentModel.X509Type != nil {
-		currentModel.X509Type = databaseUser.X509Type
-	}
-	currentModel.Username = &databaseUser.Username
 	_, _ = logger.Debugf("databaseUser:%+v", databaseUser)
+	currentModel.DatabaseName = &databaseUser.DatabaseName
+	currentModel.LdapAuthType = databaseUser.LdapAuthType
+	currentModel.AWSIAMType = databaseUser.AwsIAMType
+	currentModel.X509Type = databaseUser.X509Type
+	currentModel.Username = &databaseUser.Username
 	var roles []RoleDefinition
 
 	for _, r := range databaseUser.GetRoles() {

--- a/cfn-resources/database-user/cmd/resource/resource.go
+++ b/cfn-resources/database-user/cmd/resource/resource.go
@@ -141,7 +141,15 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		labels = append(labels, label)
 	}
 	currentModel.Labels = labels
-
+	var scopes []ScopeDefinition
+	for _, s := range databaseUser.GetScopes() {
+		scope := ScopeDefinition{
+			Name: &s.Name,
+			Type: &s.Type,
+		}
+		scopes = append(scopes, scope)
+	}
+	currentModel.Scopes = scopes
 	updateUserCFNIdentifier(currentModel)
 
 	return handler.ProgressEvent{

--- a/cfn-resources/database-user/test/inputs_2_update.template.json
+++ b/cfn-resources/database-user/test/inputs_2_update.template.json
@@ -7,14 +7,14 @@
   "Roles": [
     {
       "RoleName": "readWrite",
-      "DatabaseName": "testdb",
+      "DatabaseName": "testdb2",
       "CollectionName": "col2"
     }
   ],
   "Scopes": [
     {
       "Type": "CLUSTER",
-      "Name": "testdb"
+      "Name": "testdb2"
     }
   ]
 }


### PR DESCRIPTION
Set scopes in Read to support Scope updates

Link to any related issue(s): CLOUDP-287006 #1233 

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

