### PR TITLE
fix: Set necessary env vars for Trigger resource publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -97,11 +97,11 @@ jobs:
           MICROSOFT_TEAMS_WEBHOOK_UPDATE_URL: ${{ secrets.MICROSOFT_TEAMS_WEBHOOK_UPDATE_URL_PUBLISHING }}
 
           # Trigger
-          PROJECT_ID: '5555555'
-          APP_ID: '44444444'
-          DB_NAME: 'testDB'
-          COLLECTION_NAME: 'collection'
-          FUNC_NAME: 'func2'
-          FUNC_ID: '2222222'
-          SERVICE_ID: '111111'
+          PROJECT_ID: '67e52690518cb3468aad6c09' # existing project
+          APP_ID: '67e527bc20d289ab7cd2922e' #
+          DB_NAME: 'sample_airbnb' 
+          COLLECTION_NAME: 'listingsAndReviews'
+          FUNC_NAME: 'Function_0'
+          FUNC_ID: '67e527e78c5472bda7564977'
+          SERVICE_ID: '67e527bd20d289ab7cd292a9'
           

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,4 +95,13 @@ jobs:
           OPS_GENIE_API_KEY: ${{ secrets.OPS_GENIE_API_KEY_PUBLISHING }}
           MICROSOFT_TEAMS_WEBHOOK_CREATE_URL: ${{ secrets.MICROSOFT_TEAMS_WEBHOOK_CREATE_URL_PUBLISHING }}
           MICROSOFT_TEAMS_WEBHOOK_UPDATE_URL: ${{ secrets.MICROSOFT_TEAMS_WEBHOOK_UPDATE_URL_PUBLISHING }}
+
+          # Trigger
+          PROJECT_ID: '5555555'
+          APP_ID: '44444444'
+          DB_NAME: 'testDB'
+          COLLECTION_NAME: 'collection'
+          FUNC_NAME: 'func2'
+          FUNC_ID: '2222222'
+          SERVICE_ID: '111111'
           


### PR DESCRIPTION
## Proposed changes

Set necessary env vars for Trigger resource publishing

Link to any related issue(s): CLOUDP-308813

## Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

