### PR TITLE
feat: Adds `Description` to MongoDB::Atlas::DatabaseUser

### DIFF
--- a/cfn-resources/database-user/cmd/resource/model.go
+++ b/cfn-resources/database-user/cmd/resource/model.go
@@ -7,6 +7,7 @@ type Model struct {
 	DeleteAfterDate   *string           `json:",omitempty"`
 	AWSIAMType        *string           `json:",omitempty"`
 	DatabaseName      *string           `json:",omitempty"`
+	Description       *string           `json:",omitempty"`
 	Labels            []LabelDefinition `json:",omitempty"`
 	LdapAuthType      *string           `json:",omitempty"`
 	X509Type          *string           `json:",omitempty"`

--- a/cfn-resources/database-user/cmd/resource/resource.go
+++ b/cfn-resources/database-user/cmd/resource/resource.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
-	"go.mongodb.org/atlas-sdk/v20231115014/admin"
+	"go.mongodb.org/atlas-sdk/v20250312002/admin"
 )
 
 var CreateRequiredFields = []string{constants.DatabaseName, constants.ProjectID, constants.Roles, constants.Username}
@@ -68,7 +68,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	groupID := *currentModel.ProjectId
 
-	_, resp, err := client.Atlas20231115014.DatabaseUsersApi.CreateDatabaseUser(context.Background(), groupID, dbUser).Execute()
+	_, resp, err := client.AtlasSDK.DatabaseUsersApi.CreateDatabaseUser(context.Background(), groupID, dbUser).Execute()
 	if err != nil {
 		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
@@ -99,13 +99,14 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	groupID := *currentModel.ProjectId
 	username := *currentModel.Username
 	dbName := *currentModel.DatabaseName
-	databaseUser, resp, err := client.Atlas20231115014.DatabaseUsersApi.GetDatabaseUser(context.Background(), groupID, dbName, username).Execute()
+	databaseUser, resp, err := client.AtlasSDK.DatabaseUsersApi.GetDatabaseUser(context.Background(), groupID, dbName, username).Execute()
 	if err != nil {
 		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
 
 	_, _ = logger.Debugf("databaseUser:%+v", databaseUser)
 	currentModel.DatabaseName = &databaseUser.DatabaseName
+	currentModel.Description = databaseUser.Description
 	currentModel.LdapAuthType = databaseUser.LdapAuthType
 	currentModel.AWSIAMType = databaseUser.AwsIAMType
 	currentModel.X509Type = databaseUser.X509Type
@@ -176,7 +177,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	groupID := *currentModel.ProjectId
 
-	_, resp, err := client.Atlas20231115014.DatabaseUsersApi.UpdateDatabaseUser(context.Background(), groupID, *currentModel.DatabaseName, *currentModel.Username, dbUser).Execute()
+	_, resp, err := client.AtlasSDK.DatabaseUsersApi.UpdateDatabaseUser(context.Background(), groupID, *currentModel.DatabaseName, *currentModel.Username, dbUser).Execute()
 	if err != nil {
 		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
@@ -208,7 +209,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	groupID := *currentModel.ProjectId
 	databaseName := *currentModel.DatabaseName
 	username := *currentModel.Username
-	_, resp, err := client.Atlas20231115014.DatabaseUsersApi.DeleteDatabaseUser(context.Background(), groupID, databaseName, username).Execute()
+	resp, err := client.AtlasSDK.DatabaseUsersApi.DeleteDatabaseUser(context.Background(), groupID, databaseName, username).Execute()
 	if err != nil {
 		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
@@ -239,7 +240,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	dbUserModels := make([]interface{}, 0)
 
-	databaseUsers, resp, err := client.Atlas20231115014.DatabaseUsersApi.ListDatabaseUsers(context.Background(), groupID).Execute()
+	databaseUsers, resp, err := client.AtlasSDK.DatabaseUsersApi.ListDatabaseUsers(context.Background(), groupID).Execute()
 	if err != nil {
 		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
@@ -249,6 +250,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		databaseUser := dbUserResults[i]
 		var model = Model{
 			DatabaseName: &databaseUser.DatabaseName,
+			Description: databaseUser.Description,
 			LdapAuthType: databaseUser.LdapAuthType,
 			X509Type:     databaseUser.X509Type,
 			Username:     &databaseUser.Username,
@@ -363,6 +365,7 @@ func setModel(currentModel *Model) (*admin.CloudDatabaseUser, error) {
 		AwsIAMType:      currentModel.AWSIAMType,
 		X509Type:        currentModel.X509Type,
 		DeleteAfterDate: util.StringPtrToTimePtr(currentModel.DeleteAfterDate),
+		Description:     currentModel.Description,
 	}
 
 	if util.IsStringPresent(currentModel.Password) {

--- a/cfn-resources/database-user/cmd/resource/resource.go
+++ b/cfn-resources/database-user/cmd/resource/resource.go
@@ -250,7 +250,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		databaseUser := dbUserResults[i]
 		var model = Model{
 			DatabaseName: &databaseUser.DatabaseName,
-			Description: databaseUser.Description,
+			Description:  databaseUser.Description,
 			LdapAuthType: databaseUser.LdapAuthType,
 			X509Type:     databaseUser.X509Type,
 			Username:     &databaseUser.Username,

--- a/cfn-resources/database-user/docs/README.md
+++ b/cfn-resources/database-user/docs/README.md
@@ -15,6 +15,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
         "<a href="#deleteafterdate" title="DeleteAfterDate">DeleteAfterDate</a>" : <i>String</i>,
         "<a href="#awsiamtype" title="AWSIAMType">AWSIAMType</a>" : <i>String</i>,
         "<a href="#databasename" title="DatabaseName">DatabaseName</a>" : <i>String</i>,
+        "<a href="#description" title="Description">Description</a>" : <i>String</i>,
         "<a href="#labels" title="Labels">Labels</a>" : <i>[ <a href="labeldefinition.md">labelDefinition</a>, ... ]</i>,
         "<a href="#ldapauthtype" title="LdapAuthType">LdapAuthType</a>" : <i>String</i>,
         "<a href="#x509type" title="X509Type">X509Type</a>" : <i>String</i>,
@@ -36,6 +37,7 @@ Properties:
     <a href="#deleteafterdate" title="DeleteAfterDate">DeleteAfterDate</a>: <i>String</i>
     <a href="#awsiamtype" title="AWSIAMType">AWSIAMType</a>: <i>String</i>
     <a href="#databasename" title="DatabaseName">DatabaseName</a>: <i>String</i>
+    <a href="#description" title="Description">Description</a>: <i>String</i>
     <a href="#labels" title="Labels">Labels</a>: <i>
       - <a href="labeldefinition.md">labelDefinition</a></i>
     <a href="#ldapauthtype" title="LdapAuthType">LdapAuthType</a>: <i>String</i>
@@ -79,6 +81,16 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 MongoDB database against which the MongoDB database user authenticates. MongoDB database users must provide both a username and authentication database to log into MongoDB.  Default value is `admin`.
 
 _Required_: Yes
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Description
+
+Description of this database user.
+
+_Required_: No
 
 _Type_: String
 

--- a/cfn-resources/database-user/mongodb-atlas-databaseuser.json
+++ b/cfn-resources/database-user/mongodb-atlas-databaseuser.json
@@ -89,6 +89,10 @@
       "description": "MongoDB database against which the MongoDB database user authenticates. MongoDB database users must provide both a username and authentication database to log into MongoDB.  Default value is `admin`.",
       "type": "string"
     },
+    "Description": {
+      "description": "Description of this database user.",
+      "type": "string"
+    },
     "Labels": {
       "description": "List that contains the key-value pairs for tagging and categorizing the MongoDB database user. The labels that you define do not appear in the console.",
       "items": {

--- a/cfn-resources/database-user/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/database-user/test/cfn-test-create-inputs.sh
@@ -18,6 +18,7 @@ rm -rf inputs
 mkdir inputs
 
 projectName="${1}"
+MONGODB_ATLAS_PROFILE=${MONGODB_ATLAS_PROFILE:-"default"}
 projectId=$(atlas projects list --output json | jq --arg NAME "${projectName}" -r '.results[] | select(.name==$NAME) | .id')
 if [ -z "$projectId" ]; then
 	projectId=$(atlas projects create "${projectName}" --output=json | jq -r '.id')
@@ -32,8 +33,8 @@ echo "Check if a project is created $projectId"
 cd "$(dirname "$0")" || exit
 for inputFile in inputs_*; do
 	outputFile=${inputFile//$WORDTOREMOVE/}
-	jq --arg ProjectId "$projectId" \
-		'.ProjectId?|=$ProjectId' \
+	jq --arg ProjectId "$projectId" --arg Profile "${MONGODB_ATLAS_PROFILE}" \
+		'.ProjectId?|=$ProjectId | .Profile?|=$Profile' \
 		"$inputFile" >"../inputs/$outputFile"
 done
 cd ..

--- a/cfn-resources/database-user/test/inputs_1_create.template.json
+++ b/cfn-resources/database-user/test/inputs_1_create.template.json
@@ -1,20 +1,21 @@
 {
-    "Username" : "DataUser1",
-    "Password" : "MongoDB12345%",
-    "ProjectId" : "ProjectId",
-    "Profile" : "default",
-    "DatabaseName": "admin",
-    "Roles": [
-        { "RoleName": "readWrite",
-          "DatabaseName": "testdb",
-          "CollectionName": "col1"
-        }
-    ],
-    "Scopes": [    
-        { "Type": "CLUSTER",
-          "Name": "testdb"
-        }
-    ]
-
-
+  "Username": "DataUser1",
+  "Password": "MongoDB12345%",
+  "ProjectId": "${MONGODB_ATLAS_PROJECT_ID}",
+  "Profile": "${MONGODB_ATLAS_PROFILE}",
+  "DatabaseName": "admin",
+  "Description": "Desc 1",
+  "Roles": [
+    {
+      "RoleName": "readWrite",
+      "DatabaseName": "testdb",
+      "CollectionName": "col1"
+    }
+  ],
+  "Scopes": [
+    {
+      "Type": "CLUSTER",
+      "Name": "testdb"
+    }
+  ]
 }

--- a/cfn-resources/database-user/test/inputs_1_update.template.json
+++ b/cfn-resources/database-user/test/inputs_1_update.template.json
@@ -1,22 +1,26 @@
 {
-    "Username" : "DataUser1",
-    "Password" : "MongoDB12345%",
-    "ProjectId" : "ProjectId",
-  "Profile" : "default",
+  "Username": "DataUser1",
+  "Password": "MongoDB12345%",
+  "ProjectId": "${MONGODB_ATLAS_PROJECT_ID}",
+  "Description": "Desc 2",
+  "Profile": "${MONGODB_ATLAS_PROFILE}",
   "DatabaseName": "admin",
-    "Roles": [
-        { "RoleName": "readWrite",
-          "DatabaseName": "testdb",
-          "CollectionName": "col1"
-        },
-        { "RoleName": "read",
-          "DatabaseName": "proddb",
-          "CollectionName": "col1"
-        }
-    ],
-    "Scopes": [    
-        { "Type": "CLUSTER",
-          "Name": "testdb"
-        }
-    ]
+  "Roles": [
+    {
+      "RoleName": "readWrite",
+      "DatabaseName": "testdb",
+      "CollectionName": "col1"
+    },
+    {
+      "RoleName": "read",
+      "DatabaseName": "proddb",
+      "CollectionName": "col1"
+    }
+  ],
+  "Scopes": [
+    {
+      "Type": "CLUSTER",
+      "Name": "testdb"
+    }
+  ]
 }

--- a/cfn-resources/database-user/test/inputs_2_create.template.json
+++ b/cfn-resources/database-user/test/inputs_2_create.template.json
@@ -1,9 +1,10 @@
 {
   "Username": "arn:aws:iam::111111967292:role/cfn-admin",
   "AWSIAMType": "ROLE",
-  "ProjectId": "ProjectId",
-  "Profile": "default",
+  "ProjectId": "${MONGODB_ATLAS_PROJECT_ID}",
+  "Profile": "${MONGODB_ATLAS_PROFILE}",
   "DatabaseName": "$external",
+  "Description": "Desc 1",
   "Roles": [
     {
       "RoleName": "readWrite",

--- a/cfn-resources/database-user/test/inputs_2_update.template.json
+++ b/cfn-resources/database-user/test/inputs_2_update.template.json
@@ -1,8 +1,8 @@
 {
   "Username": "arn:aws:iam::111111967292:role/cfn-admin",
   "AWSIAMType": "ROLE",
-  "ProjectId": "ProjectId",
-  "Profile": "default",
+  "ProjectId": "${MONGODB_ATLAS_PROJECT_ID}",
+  "Profile": "${MONGODB_ATLAS_PROFILE}",
   "DatabaseName": "$external",
   "Roles": [
     {

--- a/examples/database-user/scramUser.json
+++ b/examples/database-user/scramUser.json
@@ -24,6 +24,10 @@
       "Type": "String",
       "NoEcho": "true",
       "Description": "Alphanumeric string that authenticates this database user against the database specified in databaseName. To authenticate with SCRAM-SHA, you must specify this parameter"
+    },
+    "Description": {
+      "Type": "String",
+      "Description": "Description of this database user."
     }
   },
   "Mappings": {},
@@ -48,6 +52,9 @@
         },
         "DatabaseName": {
           "Ref": "DatabaseName"
+        },
+        "Description": {
+          "Ref": "Description"
         },
         "Roles": [
           {


### PR DESCRIPTION
## Proposed changes

Adds `Description` to MongoDB::Atlas::DatabaseUser

Link to any related issue(s): CLOUDP-288714

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fmt` and formatted my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments
Example manual run:
<img width="1451" alt="image" src="https://github.com/user-attachments/assets/98d50958-5d21-4edf-af49-edbd55b54411" />

