### PR TITLE
chore: Update Go to 1.25.0

### DIFF
--- a/.github/workflows/code-health.yaml
+++ b/.github/workflows/code-health.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:
-          version: v2.3.1 # Also update GOLANGCI_VERSION variable in Makefile when updating this version
+          version: v2.4.0 # Also update GOLANGCI_VERSION variable in Makefile when updating this version
           working-directory: cfn-resources
       - name: actionlint
         run: | 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ldXflags=github.com/mongodb/mongodbatlas-cloudformation-resources/util.defaultLo
 ldXflagsD=github.com/mongodb/mongodbatlas-cloudformation-resources/util.defaultLogLevel=debug
 
 MOCKERY_VERSION=v3.5.3
-GOLANGCI_VERSION=v2.3.1 # Also update golangci-lint GH action in code-health.yml when updating this version
+GOLANGCI_VERSION=v2.4.0 # Also update golangci-lint GH action in code-health.yml when updating this version
 
 .PHONY: submit
 submit:

--- a/cfn-resources/.golangci.yml
+++ b/cfn-resources/.golangci.yml
@@ -101,6 +101,8 @@ linters:
     rules:
       - path: (.+)\.go$
         text: declaration of ".*" shadows declaration at line .*
+      - path: util/.*\.go$
+        text: "var-naming: avoid meaningless package names"
 formatters:
   enable:
     - gofmt

--- a/cfn-resources/go.mod
+++ b/cfn-resources/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/mongodbatlas-cloudformation-resources
 
-go 1.24.6
+go 1.25.0
 
 // Replacing with local copy of Atlas SDK v20231115014 to support new AdvancedConfiguration in *admin.AdvancedClusterDescription
 replace go.mongodb.org/atlas-sdk/v20231115014 => ../vendor/go.mongodb.org/atlas-sdk/v20231115014

--- a/cfn-resources/project/Makefile
+++ b/cfn-resources/project/Makefile
@@ -35,5 +35,3 @@ run-contract-testing:
 	make build
 	sam local start-lambda &
 	cfn test --function-name TestEntrypoint --verbose
-
-# temporary change

--- a/cfn-resources/project/Makefile
+++ b/cfn-resources/project/Makefile
@@ -35,3 +35,5 @@ run-contract-testing:
 	make build
 	sam local start-lambda &
 	cfn test --function-name TestEntrypoint --verbose
+
+# temporary change

--- a/cfn-resources/util/util.go
+++ b/cfn-resources/util/util.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package util //nolint:revive // util is an established package name in this codebase
+package util
 
 import (
 	"context"


### PR DESCRIPTION
## Proposed changes

Update Go to 1.25.0.

Also updated Go linter to 2.4.0.


<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->
## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fmt` and formatted my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments

