### PR TITLE
chore: Re-enable test status check in cfn-publishing-helper.sh

### DIFF
--- a/cfn-resources/cfn-publishing-helper.sh
+++ b/cfn-resources/cfn-publishing-helper.sh
@@ -86,11 +86,10 @@ for resource in ${resources}; do
 		status=$(echo "${dt}" | jq -r '.TypeTestsStatus')
 		echo "status=${status}"
 	done
-	# TODO: CLOUDP-380757 - Revert change when normal publishing is fixed.
-	# if [[ "${status}" == "FAILED" || "${status}" == "NOT_TESTED" ]]; then
-	# 	echo "Test_type STATUS is ${status}"
-	# 	exit 1
-	# fi
+	if [[ "${status}" == "FAILED" || "${status}" == "NOT_TESTED" ]]; then
+		echo "Test_type STATUS is ${status}"
+		exit 1
+	fi
 	# Fetch the resource type
 	cd -
 done


### PR DESCRIPTION

## Proposed changes

_Jira ticket:_ CLOUDP-380757

Reverts the workaround introduced in #1572 that commented out the test status validation in `cfn-publishing-helper.sh`. AWS's normal publishing flow is now fixed, so the guard that exits on `FAILED` or `NOT_TESTED` status is restored.

Link to any related issue(s): CLOUDP-380757


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fix` and verified my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments