### PR TITLE
chore: Refresh test status after NOT_TESTED re-trigger in cfn-publishing-helper.sh

### DIFF
--- a/cfn-resources/cfn-publishing-helper.sh
+++ b/cfn-resources/cfn-publishing-helper.sh
@@ -80,6 +80,7 @@ for resource in ${resources}; do
 		sleep 60
 		dt=$(aws cloudformation describe-type --arn "${arn}")
 		status=$(echo "${dt}" | jq -r '.TypeTestsStatus')
+		echo "status=${status}"
 	fi
 
 	while [[ "$status" == "IN_PROGRESS" ]]; do

--- a/cfn-resources/cfn-publishing-helper.sh
+++ b/cfn-resources/cfn-publishing-helper.sh
@@ -80,7 +80,7 @@ for resource in ${resources}; do
 		sleep 60
 		dt=$(aws cloudformation describe-type --arn "${arn}")
 		status=$(echo "${dt}" | jq -r '.TypeTestsStatus')
-		echo "status=${status}"
+		echo "status after NOT_TESTED re-trigger=${status}"
 	fi
 
 	while [[ "$status" == "IN_PROGRESS" ]]; do

--- a/cfn-resources/cfn-publishing-helper.sh
+++ b/cfn-resources/cfn-publishing-helper.sh
@@ -78,6 +78,8 @@ for resource in ${resources}; do
 		test_type_resp=$(aws cloudformation test-type --type RESOURCE --type-name "${res_type}" --log-delivery-bucket "${_CFN_TEST_LOG_BUCKET}" --version-id "${version}")
 		arn=$(echo "${test_type_resp}" | jq -r '.TypeVersionArn')
 		sleep 60
+		dt=$(aws cloudformation describe-type --arn "${arn}")
+		status=$(echo "${dt}" | jq -r '.TypeTestsStatus')
 	fi
 
 	while [[ "$status" == "IN_PROGRESS" ]]; do


### PR DESCRIPTION

## Proposed changes

_Jira ticket:_ CLOUDP-380757

Follow-up to #1633, addressing an issue caught by Copilot during that review.

After re-triggering `test-type` when the initial status is `NOT_TESTED`, the script slept 60s but never refreshed `dt`/`status` before the while loop and final status check. Both used the stale `NOT_TESTED` value, so the while loop was immediately skipped and the final check always exited 1, even if the re-triggered test had since moved to `IN_PROGRESS` or `PASSED`. Adds a re-fetch of the describe-type result after the sleep (using the new ARN) and echoes the status, following the same pattern as the `IN_PROGRESS` while loop below.

Link to any related issue(s): CLOUDP-380757


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fix` and verified my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments