### PR TITLE
chore: Update stream-processor test naming to follow CLOUDP-299242 convention

### DIFF
--- a/cfn-resources/stream-processor/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/stream-processor/test/cfn-test-create-inputs.sh
@@ -31,7 +31,7 @@ fi
 echo -e "=====\nrun this command to clean up\n=====\nmongocli iam projects delete ${projectId} --force\n====="
 
 # Create Stream Instance/Workspace (this is a LONG-RUNNING operation, can take 10-30+ minutes)
-workspaceName="stream-workspace-$(date +%s)-$RANDOM"
+workspaceName="ct-stream-workspace-$(date +%s)-$RANDOM"
 cloudProvider="AWS"
 
 echo -e "Creating Stream Instance/Workspace \"${workspaceName}\" (this may take 10-30+ minutes)...\n"
@@ -49,8 +49,8 @@ done
 
 # For inputs_3 (DLQ testing), we need a cluster and stream connection
 # Create cluster for DLQ connection (if needed)
-clusterName="cluster-$(date +%s)-$RANDOM"
-connectionName="stream-connection-$(date +%s)-$RANDOM"
+clusterName="ct-cluster-$(date +%s)-$RANDOM"
+connectionName="ct-stream-conn-$(date +%s)-$RANDOM"
 
 echo -e "Creating Cluster \"${clusterName}\" for DLQ connection...\n"
 atlas clusters create "${clusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --diskSizeGB 10 --output=json
@@ -106,8 +106,8 @@ rm -f "${sampleConnectionConfig}"
 
 # Create Kafka connections for inputs_4 and inputs_5 (Kafka to Cluster and Cluster to Kafka)
 # Using placeholder values matching Terraform tests (as per MongoDB team guidance)
-kafkaSourceConnectionName="KafkaConnectionSrc-$(date +%s)-$RANDOM"
-kafkaSinkConnectionName="KafkaConnectionDest-$(date +%s)-$RANDOM"
+kafkaSourceConnectionName="ct-kafka-src-$(date +%s)-$RANDOM"
+kafkaSinkConnectionName="ct-kafka-dest-$(date +%s)-$RANDOM"
 
 echo -e "Creating Kafka Source Connection \"${kafkaSourceConnectionName}\" for inputs_4...\n"
 kafkaSourceConnectionConfig=$(mktemp).json

--- a/cfn-resources/stream-processor/test/contract-testing/cfn-test-create.sh
+++ b/cfn-resources/stream-processor/test/contract-testing/cfn-test-create.sh
@@ -5,7 +5,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-projectName="cfn-test-bot-$(date +%s)-$RANDOM"
+projectName="ct-stream-processor-$(date +%s)-$RANDOM"
 
 # create project
 projectId=$(atlas projects create "${projectName}" --output=json | jq -r '.id')


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-343669

Update project, workspace, cluster, and connection name prefixes in the `stream-processor` contract test scripts to use `ct-` prefixes, consistent with the cleanup allowlist and the naming convention from CLOUDP-299242. Investigation found the Read, Update, and Delete handlers already return `FAILED + HandlerErrorCode: "NotFound"` correctly when a resource does not exist (present since the initial implementation), so no handler code change is needed.

Link to any related issue(s): CLOUDP-343669


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fix` and verified my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments