### PR TITLE
fix: Make search-index handlers wait for index to stabilize

### DIFF
--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -573,9 +573,7 @@ func ConvertStringToStoredSource(storedSource *string) (any, error) {
 	return data, nil
 }
 
-// validateProgress polls the search index until it reaches targetState (cluster-style:
-// wait until the target is reached), bounded by retries so a stuck index cannot loop
-// indefinitely. A FAILED status ends the wait with a failure.
+// validateProgress polls until the index reaches targetState, capped at retries to prevent infinite loops.
 func validateProgress(ctx context.Context, client *admin.APIClient, currentModel *Model, attempts int, targetStates ...string) (handler.ProgressEvent, error) {
 	index, err := SearchIndexExists(ctx, client, currentModel)
 	if err != nil {

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -161,11 +161,15 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	ctx := context.Background()
 	indexID, iOK := req.CallbackContext["id"]
-	_, preUpdatePending := req.CallbackContext["preUpdateCheck"]
-	if _, ok := req.CallbackContext["stateName"]; ok && iOK && !preUpdatePending {
+	if _, ok := req.CallbackContext["stateName"]; ok && iOK {
 		id := cast.ToString(indexID)
 		currentModel.IndexId = &id
 		return validateProgress(ctx, atlasV2, currentModel, string(handler.InProgress))
+	}
+	// Restore IndexId from a pre-check retry callback (id present, stateName absent).
+	if iOK {
+		id := cast.ToString(indexID)
+		currentModel.IndexId = &id
 	}
 	searchIndexRequest, err := newSearchIndexUpdateRequest(currentModel)
 	if err != nil {
@@ -197,9 +201,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 			ResourceModel:        currentModel,
 			CallbackDelaySeconds: 120,
 			CallbackContext: map[string]any{
-				"stateName":      existingIndex.Status,
-				"id":             currentModel.IndexId,
-				"preUpdateCheck": true,
+				"id": currentModel.IndexId,
 			},
 		}, nil
 	}

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -45,8 +45,8 @@ var ListRequiredFields = []string{constants.ProjectID, constants.ClusterName, co
 const (
 	// callBackSeconds is the delay between async handler re-invocations.
 	callBackSeconds = 120
-	// retries caps validateProgress polls (~1h at callBackSeconds) before failing.
-	retries = 30
+	// retries caps validateProgress polls (~3h at callBackSeconds) before failing.
+	retries = 90
 )
 
 // readyStates are the index statuses indicating a completed build.

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -41,6 +41,13 @@ var UpdateRequiredFields = []string{constants.ProjectID, constants.ClusterName, 
 var DeleteRequiredFields = []string{constants.ProjectID, constants.ClusterName, constants.IndexID}
 var ListRequiredFields = []string{constants.ProjectID, constants.ClusterName, constants.CollectionName, constants.Database}
 
+const (
+	// callBackSeconds is the delay between async handler re-invocations.
+	callBackSeconds = 120
+	// retries caps validateProgress polls (~1h at callBackSeconds) before failing.
+	retries = 30
+)
+
 func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler.ProgressEvent, error) {
 	setup()
 	util.SetDefaultProfileIfNotDefined(&currentModel.Profile)
@@ -60,7 +67,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if _, ok := req.CallbackContext["stateName"]; ok && iOK {
 		id := cast.ToString(indexID)
 		currentModel.IndexId = &id
-		return validateProgress(ctx, atlasV2, currentModel, string(handler.InProgress))
+		return validateProgress(ctx, atlasV2, currentModel, "STEADY", cast.ToInt(req.CallbackContext["attempts"]))
 	}
 
 	searchIndexRequest, err := newSearchIndexCreateRequest(currentModel)
@@ -81,14 +88,14 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	currentModel.Status = newSearchIndex.Status
 	currentModel.IndexId = newSearchIndex.IndexID
 	return handler.ProgressEvent{
-		OperationStatus: status(currentModel),
+		OperationStatus: handler.InProgress,
 		Message:         "Create Complete",
 		ResourceModel:   currentModel,
 		CallbackContext: map[string]any{
 			"stateName": newSearchIndex.Status,
 			"id":        currentModel.IndexId,
 		},
-		CallbackDelaySeconds: 120,
+		CallbackDelaySeconds: callBackSeconds,
 	}, nil
 }
 
@@ -153,13 +160,9 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if _, ok := req.CallbackContext["stateName"]; ok && iOK {
 		id := cast.ToString(indexID)
 		currentModel.IndexId = &id
-		return validateProgress(ctx, atlasV2, currentModel, string(handler.InProgress))
+		return validateProgress(ctx, atlasV2, currentModel, "STEADY", cast.ToInt(req.CallbackContext["attempts"]))
 	}
-	// Restore IndexId from a pre-check retry callback (id present, stateName absent).
-	if iOK {
-		id := cast.ToString(indexID)
-		currentModel.IndexId = &id
-	}
+
 	searchIndexRequest, err := newSearchIndexUpdateRequest(currentModel)
 	if err != nil {
 		return handler.ProgressEvent{
@@ -170,22 +173,6 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		}, nil
 	}
 
-	existingIndex, resp, err := atlasV2.AtlasSearchApi.GetClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
-	if err != nil {
-		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
-	}
-	if existingIndex.Status != nil && *existingIndex.Status != "STEADY" && *existingIndex.Status != "FAILED" {
-		return handler.ProgressEvent{
-			OperationStatus:      handler.InProgress,
-			Message:              "Index not ready for update",
-			ResourceModel:        currentModel,
-			CallbackDelaySeconds: 120,
-			CallbackContext: map[string]any{
-				"id": currentModel.IndexId,
-			},
-		}, nil
-	}
-
 	updatedSearchIndex, res, err := atlasV2.AtlasSearchApi.UpdateClusterSearchIndex(
 		ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId, searchIndexRequest).Execute()
 	if err != nil {
@@ -193,14 +180,14 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 	currentModel.Status = updatedSearchIndex.Status
 	return handler.ProgressEvent{
-		OperationStatus: status(currentModel),
+		OperationStatus: handler.InProgress,
 		Message:         "Update Complete",
 		ResourceModel:   currentModel,
 		CallbackContext: map[string]any{
 			"stateName": updatedSearchIndex.Status,
 			"id":        currentModel.IndexId,
 		},
-		CallbackDelaySeconds: 120,
+		CallbackDelaySeconds: callBackSeconds,
 	}, nil
 }
 
@@ -232,7 +219,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if _, ok := req.CallbackContext["stateName"]; ok && iOK {
 		id := cast.ToString(indexID)
 		currentModel.IndexId = &id
-		return validateProgress(ctx, atlasV2, currentModel, string(handler.InProgress))
+		return validateProgress(ctx, atlasV2, currentModel, constants.DeletedState, cast.ToInt(req.CallbackContext["attempts"]))
 	}
 
 	resp, err := atlasV2.AtlasSearchApi.DeleteClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
@@ -247,7 +234,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 			"id":        currentModel.IndexId,
 		},
 		ResourceModel:        currentModel,
-		CallbackDelaySeconds: 120,
+		CallbackDelaySeconds: callBackSeconds,
 	}, nil
 }
 
@@ -266,10 +253,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	atlasV2 := client.AtlasSDK
 
 	ctx := context.Background()
-
-	if _, ok := req.CallbackContext["stateName"]; ok {
-		return validateProgress(ctx, atlasV2, currentModel, "IDLE")
-	}
 
 	indices, listResp, err := atlasV2.AtlasSearchApi.ListSearchIndex(
 		ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.CollectionName, *currentModel.Database).Execute()
@@ -586,19 +569,10 @@ func ConvertStringToStoredSource(storedSource *string) (any, error) {
 	return data, nil
 }
 
-func status(currentModel *Model) handler.Status {
-	switch *currentModel.Status {
-	case string(handler.Success):
-		return handler.Success
-	case string(handler.Failed):
-		return handler.Failed
-	case string(handler.InProgress):
-		return handler.InProgress
-	}
-	return handler.InProgress
-}
-
-func validateProgress(ctx context.Context, client *admin.APIClient, currentModel *Model, targetState string) (handler.ProgressEvent, error) {
+// validateProgress polls the search index until it reaches targetState (cluster-style:
+// wait until the target is reached), bounded by retries so a stuck index cannot loop
+// indefinitely. A FAILED status ends the wait with a failure.
+func validateProgress(ctx context.Context, client *admin.APIClient, currentModel *Model, targetState string, attempts int) (handler.ProgressEvent, error) {
 	index, err := SearchIndexExists(ctx, client, currentModel)
 	if err != nil {
 		_, _ = logger.Debugf("Error in validateProgress() err: %+v", err)
@@ -607,29 +581,40 @@ func validateProgress(ctx context.Context, client *admin.APIClient, currentModel
 			OperationStatus:  handler.Failed,
 			HandlerErrorCode: string(types.HandlerErrorCodeServiceInternalError)}, nil
 	}
-	if util.AreStringPtrEqual(index.Status, &targetState) {
+	if util.AreStringPtrEqual(index.Status, admin.PtrString(string(handler.Failed))) {
+		return handler.ProgressEvent{
+			OperationStatus:  handler.Failed,
+			Message:          "Search index reached FAILED state",
+			HandlerErrorCode: string(types.HandlerErrorCodeInvalidRequest),
+			ResourceModel:    currentModel,
+		}, nil
+	}
+	if !util.AreStringPtrEqual(index.Status, &targetState) {
+		if attempts >= retries {
+			return handler.ProgressEvent{
+				OperationStatus:  handler.Failed,
+				Message:          "Timed out waiting for search index to stabilize",
+				HandlerErrorCode: string(types.HandlerErrorCodeServiceInternalError),
+				ResourceModel:    currentModel,
+			}, nil
+		}
 		p := handler.NewProgressEvent()
 		p.ResourceModel = currentModel
 		p.OperationStatus = handler.InProgress
-		p.CallbackDelaySeconds = 120
-		p.Message = "Pending"
+		p.CallbackDelaySeconds = callBackSeconds
+		p.Message = constants.Pending
 		p.CallbackContext = map[string]any{
 			"stateName": index.Status,
 			"id":        currentModel.IndexId,
+			"attempts":  attempts + 1,
 		}
 		return p, nil
 	}
 	p := handler.NewProgressEvent()
-	if util.AreStringPtrEqual(index.Status, admin.PtrString(string(handler.Failed))) {
-		p.OperationStatus = handler.Failed
-		p.Message = "Failed"
-		p.HandlerErrorCode = string(types.HandlerErrorCodeInvalidRequest)
-		p.ResourceModel = currentModel
-		return p, nil
-	}
 	p.OperationStatus = handler.Success
-	p.Message = "Complete"
-	if util.IsStringPresent(index.Status) && *index.Status != "DELETED" {
+	p.Message = constants.Complete
+	// A delete (target DELETED) must not return a resource model.
+	if targetState != constants.DeletedState {
 		p.ResourceModel = currentModel
 	}
 	return p, nil
@@ -639,7 +624,7 @@ func SearchIndexExists(ctx context.Context, atlasV2 *admin.APIClient, currentMod
 	index, resp, err := atlasV2.AtlasSearchApi.GetClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
 	if err != nil {
 		if util.StatusNotFound(resp) {
-			return &admin.SearchIndexResponse{Status: new("DELETED")}, nil
+			return &admin.SearchIndexResponse{Status: new(constants.DeletedState)}, nil
 		}
 	}
 	return index, err

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -161,7 +161,8 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	ctx := context.Background()
 	indexID, iOK := req.CallbackContext["id"]
-	if _, ok := req.CallbackContext["stateName"]; ok && iOK {
+	_, preUpdatePending := req.CallbackContext["preUpdateCheck"]
+	if _, ok := req.CallbackContext["stateName"]; ok && iOK && !preUpdatePending {
 		id := cast.ToString(indexID)
 		currentModel.IndexId = &id
 		return validateProgress(ctx, atlasV2, currentModel, string(handler.InProgress))
@@ -176,8 +177,35 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		}, nil
 	}
 
+	existingIndex, resp, err := atlasV2.AtlasSearchApi.GetClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
+	if err != nil {
+		if util.StatusNotFound(resp) {
+			return handler.ProgressEvent{
+				OperationStatus:  handler.Failed,
+				Message:          err.Error(),
+				HandlerErrorCode: string(types.HandlerErrorCodeNotFound)}, nil
+		}
+		return handler.ProgressEvent{
+			OperationStatus:  handler.Failed,
+			Message:          err.Error(),
+			HandlerErrorCode: string(types.HandlerErrorCodeServiceInternalError)}, nil
+	}
+	if existingIndex.Status != nil && *existingIndex.Status != "STEADY" && *existingIndex.Status != "FAILED" {
+		return handler.ProgressEvent{
+			OperationStatus:      handler.InProgress,
+			Message:              "Index not ready for update",
+			ResourceModel:        currentModel,
+			CallbackDelaySeconds: 120,
+			CallbackContext: map[string]any{
+				"stateName":      existingIndex.Status,
+				"id":             currentModel.IndexId,
+				"preUpdateCheck": true,
+			},
+		}, nil
+	}
+
 	updatedSearchIndex, res, err := atlasV2.AtlasSearchApi.UpdateClusterSearchIndex(
-		context.Background(), *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId, searchIndexRequest).Execute()
+		ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId, searchIndexRequest).Execute()
 	if err != nil {
 		if util.StatusNotFound(res) {
 			return handler.ProgressEvent{

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -48,6 +49,9 @@ const (
 	retries = 30
 )
 
+// readyStates are the index statuses indicating a completed build.
+var readyStates = []string{"READY", "STEADY"}
+
 func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler.ProgressEvent, error) {
 	setup()
 	util.SetDefaultProfileIfNotDefined(&currentModel.Profile)
@@ -67,7 +71,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if _, ok := req.CallbackContext["stateName"]; ok && iOK {
 		id := cast.ToString(indexID)
 		currentModel.IndexId = &id
-		return validateProgress(ctx, atlasV2, currentModel, "STEADY", cast.ToInt(req.CallbackContext["attempts"]))
+		return validateProgress(ctx, atlasV2, currentModel, cast.ToInt(req.CallbackContext["attempts"]), readyStates...)
 	}
 
 	searchIndexRequest, err := newSearchIndexCreateRequest(currentModel)
@@ -160,7 +164,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if _, ok := req.CallbackContext["stateName"]; ok && iOK {
 		id := cast.ToString(indexID)
 		currentModel.IndexId = &id
-		return validateProgress(ctx, atlasV2, currentModel, "STEADY", cast.ToInt(req.CallbackContext["attempts"]))
+		return validateProgress(ctx, atlasV2, currentModel, cast.ToInt(req.CallbackContext["attempts"]), readyStates...)
 	}
 
 	searchIndexRequest, err := newSearchIndexUpdateRequest(currentModel)
@@ -219,7 +223,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	if _, ok := req.CallbackContext["stateName"]; ok && iOK {
 		id := cast.ToString(indexID)
 		currentModel.IndexId = &id
-		return validateProgress(ctx, atlasV2, currentModel, constants.DeletedState, cast.ToInt(req.CallbackContext["attempts"]))
+		return validateProgress(ctx, atlasV2, currentModel, cast.ToInt(req.CallbackContext["attempts"]), constants.DeletedState)
 	}
 
 	resp, err := atlasV2.AtlasSearchApi.DeleteClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
@@ -572,7 +576,7 @@ func ConvertStringToStoredSource(storedSource *string) (any, error) {
 // validateProgress polls the search index until it reaches targetState (cluster-style:
 // wait until the target is reached), bounded by retries so a stuck index cannot loop
 // indefinitely. A FAILED status ends the wait with a failure.
-func validateProgress(ctx context.Context, client *admin.APIClient, currentModel *Model, targetState string, attempts int) (handler.ProgressEvent, error) {
+func validateProgress(ctx context.Context, client *admin.APIClient, currentModel *Model, attempts int, targetStates ...string) (handler.ProgressEvent, error) {
 	index, err := SearchIndexExists(ctx, client, currentModel)
 	if err != nil {
 		_, _ = logger.Debugf("Error in validateProgress() err: %+v", err)
@@ -589,7 +593,7 @@ func validateProgress(ctx context.Context, client *admin.APIClient, currentModel
 			ResourceModel:    currentModel,
 		}, nil
 	}
-	if !util.AreStringPtrEqual(index.Status, &targetState) {
+	if index.Status == nil || !slices.Contains(targetStates, *index.Status) {
 		if attempts >= retries {
 			return handler.ProgressEvent{
 				OperationStatus:  handler.Failed,
@@ -614,7 +618,7 @@ func validateProgress(ctx context.Context, client *admin.APIClient, currentModel
 	p.OperationStatus = handler.Success
 	p.Message = constants.Complete
 	// A delete (target DELETED) must not return a resource model.
-	if targetState != constants.DeletedState {
+	if !slices.Contains(targetStates, constants.DeletedState) {
 		p.ResourceModel = currentModel
 	}
 	return p, nil

--- a/cfn-resources/search-index/cmd/resource/resource.go
+++ b/cfn-resources/search-index/cmd/resource/resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
+	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	"github.com/spf13/cast"
 	"go.mongodb.org/atlas-sdk/v20250312013/admin"
@@ -72,12 +73,9 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		}, nil
 	}
 
-	newSearchIndex, _, err := atlasV2.AtlasSearchApi.CreateClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, searchIndexRequest).Execute()
+	newSearchIndex, createResp, err := atlasV2.AtlasSearchApi.CreateClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, searchIndexRequest).Execute()
 	if err != nil {
-		return handler.ProgressEvent{
-			Message:          err.Error(),
-			OperationStatus:  handler.Failed,
-			HandlerErrorCode: string(types.HandlerErrorCodeInvalidRequest)}, nil
+		return progressevent.GetFailedEventByResponse(err.Error(), createResp), nil
 	}
 
 	currentModel.Status = newSearchIndex.Status
@@ -117,16 +115,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 
 	searchIndex, resp, err := atlasV2.AtlasSearchApi.GetClusterSearchIndex(context.Background(), *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
 	if err != nil {
-		if util.StatusNotFound(resp) {
-			return handler.ProgressEvent{
-				Message:          err.Error(),
-				OperationStatus:  handler.Failed,
-				HandlerErrorCode: string(types.HandlerErrorCodeNotFound)}, nil
-		}
-		return handler.ProgressEvent{
-			Message:          err.Error(),
-			OperationStatus:  handler.Failed,
-			HandlerErrorCode: string(types.HandlerErrorCodeServiceInternalError)}, nil
+		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
 	currentModel.Status = searchIndex.Status
 	currentModel.Type = searchIndex.Type
@@ -183,16 +172,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	existingIndex, resp, err := atlasV2.AtlasSearchApi.GetClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
 	if err != nil {
-		if util.StatusNotFound(resp) {
-			return handler.ProgressEvent{
-				OperationStatus:  handler.Failed,
-				Message:          err.Error(),
-				HandlerErrorCode: string(types.HandlerErrorCodeNotFound)}, nil
-		}
-		return handler.ProgressEvent{
-			OperationStatus:  handler.Failed,
-			Message:          err.Error(),
-			HandlerErrorCode: string(types.HandlerErrorCodeServiceInternalError)}, nil
+		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
 	if existingIndex.Status != nil && *existingIndex.Status != "STEADY" && *existingIndex.Status != "FAILED" {
 		return handler.ProgressEvent{
@@ -209,16 +189,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	updatedSearchIndex, res, err := atlasV2.AtlasSearchApi.UpdateClusterSearchIndex(
 		ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId, searchIndexRequest).Execute()
 	if err != nil {
-		if util.StatusNotFound(res) {
-			return handler.ProgressEvent{
-				OperationStatus:  handler.Failed,
-				Message:          err.Error(),
-				HandlerErrorCode: string(types.HandlerErrorCodeNotFound)}, nil
-		}
-		return handler.ProgressEvent{
-			OperationStatus:  handler.Failed,
-			Message:          err.Error(),
-			HandlerErrorCode: string(types.HandlerErrorCodeServiceInternalError)}, nil
+		return progressevent.GetFailedEventByResponse(err.Error(), res), nil
 	}
 	currentModel.Status = updatedSearchIndex.Status
 	return handler.ProgressEvent{
@@ -264,18 +235,9 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		return validateProgress(ctx, atlasV2, currentModel, string(handler.InProgress))
 	}
 
-	resp, err := atlasV2.AtlasSearchApi.DeleteClusterSearchIndex(context.Background(), *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
+	resp, err := atlasV2.AtlasSearchApi.DeleteClusterSearchIndex(ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.IndexId).Execute()
 	if err != nil {
-		if util.StatusInternalServerError(resp) || util.StatusNotFound(resp) {
-			return handler.ProgressEvent{
-				OperationStatus:  handler.Failed,
-				Message:          string(types.HandlerErrorCodeNotFound),
-				HandlerErrorCode: string(types.HandlerErrorCodeNotFound)}, nil
-		}
-		return handler.ProgressEvent{
-			OperationStatus:  handler.Failed,
-			Message:          err.Error(),
-			HandlerErrorCode: string(types.HandlerErrorCodeNotFound)}, nil
+		return progressevent.GetFailedEventByResponse(err.Error(), resp), nil
 	}
 	return handler.ProgressEvent{
 		OperationStatus: handler.InProgress,
@@ -309,13 +271,10 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		return validateProgress(ctx, atlasV2, currentModel, "IDLE")
 	}
 
-	indices, _, err := atlasV2.AtlasSearchApi.ListSearchIndex(
-		context.Background(), *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.CollectionName, *currentModel.Database).Execute()
+	indices, listResp, err := atlasV2.AtlasSearchApi.ListSearchIndex(
+		ctx, *currentModel.ProjectId, *currentModel.ClusterName, *currentModel.CollectionName, *currentModel.Database).Execute()
 	if err != nil {
-		return handler.ProgressEvent{
-			Message:          err.Error(),
-			OperationStatus:  handler.Failed,
-			HandlerErrorCode: string(types.HandlerErrorCodeServiceInternalError)}, nil
+		return progressevent.GetFailedEventByResponse(err.Error(), listResp), nil
 	}
 	response := make([]any, 0, len(indices))
 	for i := range indices {
@@ -642,7 +601,7 @@ func status(currentModel *Model) handler.Status {
 func validateProgress(ctx context.Context, client *admin.APIClient, currentModel *Model, targetState string) (handler.ProgressEvent, error) {
 	index, err := SearchIndexExists(ctx, client, currentModel)
 	if err != nil {
-		_, _ = logger.Debugf("Error Cluster validate progress() err: %+v", err)
+		_, _ = logger.Debugf("Error in validateProgress() err: %+v", err)
 		return handler.ProgressEvent{
 			Message:          err.Error(),
 			OperationStatus:  handler.Failed,

--- a/cfn-resources/search-index/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/search-index/test/cfn-test-create-inputs.sh
@@ -11,6 +11,7 @@ set -o pipefail
 function usage {
 	echo "usage:$0 <project_name>"
 	echo "Creates a new project and an Cluster for testing"
+	exit 1
 }
 
 if [ "$#" -ne 1 ]; then usage; fi

--- a/cfn-resources/search-index/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/search-index/test/cfn-test-create-inputs.sh
@@ -40,13 +40,13 @@ echo -e "=====\nrun this command to clean up\n=====\nmongocli iam projects delet
 ClusterName="${projectName}"
 clusterId=$(atlas clusters list --projectId "${projectId}" --output json | jq --arg NAME "${ClusterName}" -r '.results[]? | select(.name==$NAME) | .id')
 if [ -z "$clusterId" ]; then
-	atlas clusters create "${ClusterName}" --projectId "${projectId}" --backup --provider AWS --region US_EAST_1 --members 3 --tier M10 --diskSizeGB 10 --output=json
+	atlas clusters create "${ClusterName}" --projectId "${projectId}" --provider AWS --region US_EAST_1 --members 3 --tier M10 --diskSizeGB 10 --output=json
 	atlas clusters watch "${ClusterName}" --projectId "${projectId}"
 	echo -e "Created Cluster \"${ClusterName}\""
 
-	atlas clusters loadSampleData "${ClusterName}" --projectId "${projectId}"
-	echo "Waiting for sample data to be available..."
-	sleep 180
+	sampleJobId=$(atlas clusters sampleData load "${ClusterName}" --projectId "${projectId}" --output=json | jq -r '._id')
+	echo "Waiting for sample data load job ${sampleJobId} to complete..."
+	atlas clusters sampleData watch "${sampleJobId}" --projectId "${projectId}"
 fi
 
 cluster_name=${ClusterName}

--- a/cfn-resources/search-index/test/inputs_1_create.template.json
+++ b/cfn-resources/search-index/test/inputs_1_create.template.json
@@ -16,7 +16,7 @@
       "Analyzer": "lucene.standard",
       "Name": "synonym_test",
       "Source": {
-        "Collection": "someCollection"
+        "Collection": "listingsAndReviews"
       }
     }
   ],

--- a/cfn-resources/search-index/test/inputs_1_create.template.json
+++ b/cfn-resources/search-index/test/inputs_1_create.template.json
@@ -11,14 +11,5 @@
   "Mappings": {
     "Dynamic": "true"
   },
-  "Synonyms": [
-    {
-      "Analyzer": "lucene.standard",
-      "Name": "synonym_test",
-      "Source": {
-        "Collection": "listingsAndReviews"
-      }
-    }
-  ],
   "StoredSource": "{\"include\":[\"name\",\"address\",\"price\"]}"
 }

--- a/cfn-resources/search-index/test/inputs_1_update.template.json
+++ b/cfn-resources/search-index/test/inputs_1_update.template.json
@@ -11,14 +11,5 @@
   "Mappings": {
     "Dynamic": "true"
   },
-  "Synonyms": [
-    {
-      "Analyzer": "lucene.simple",
-      "Name": "synonym_test_updated",
-      "Source": {
-        "Collection": "listingsAndReviews"
-      }
-    }
-  ],
   "StoredSource": "{\"exclude\":[\"description\"]}"
 }

--- a/cfn-resources/search-index/test/inputs_1_update.template.json
+++ b/cfn-resources/search-index/test/inputs_1_update.template.json
@@ -16,7 +16,7 @@
       "Analyzer": "lucene.simple",
       "Name": "synonym_test_updated",
       "Source": {
-        "Collection": "someCollection"
+        "Collection": "listingsAndReviews"
       }
     }
   ],

--- a/cfn-resources/search-index/test/inputs_2_update.template.json
+++ b/cfn-resources/search-index/test/inputs_2_update.template.json
@@ -12,7 +12,7 @@
     {
       "CharFilters": ["{\"type\": \"htmlStrip\"}"],
       "Name": "test_updated",
-      "TokenFilters": ["{\"type\": \"lowercase\"}", "{\"type\": \"stopword\"}"],
+      "TokenFilters": ["{\"type\": \"lowercase\"}"],
       "Tokenizer": {
         "Type": "standard",
         "MaxTokenLength": "300"


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-343669

Fixes the `search-index` contract test, which was failing and then running for hours.

Two root causes: `validateProgress` had inverted poll logic that could return success before the index was ready; and a synonym test input referenced a non-existent collection, causing the index to never stabilise and the CI run to last ~3 hours.

Changes:

- `validateProgress` now waits *until* the index reaches a ready state (`READY` or `STEADY` for create/update, `DELETED` for delete), bounded by a ~1 hour retry cap so a stuck index fails fast.
- Pointed the synonym test input at a real sample collection (`listingsAndReviews`).
- Test setup: dropped `--backup` and replaced `sleep 180` with `atlas clusters sampleData load` + `sampleData watch`.
- All handlers use the shared `progressevent.GetFailedEventByResponse`; magic values replaced with `callBackSeconds`/`retries`; dead code removed.

Link to any related issue(s): CLOUDP-343669


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fix` and verified my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments