### PR TITLE
fix: Fix api-key contract test secret name collision

### DIFF
--- a/cfn-resources/api-key/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/api-key/test/cfn-test-create-inputs.sh
@@ -10,6 +10,7 @@ set -o pipefail
 
 function usage {
 	echo "Creates a template for org apikey creation"
+	exit 1
 }
 
 if [[ "$*" == help ]]; then usage; fi
@@ -39,6 +40,7 @@ fi
 
 # create aws secret key
 awsSecretName="mongodb/atlas/apikey/${projectName}"
+aws secretsmanager delete-secret --secret-id "${awsSecretName}" --force-delete-without-recovery 2>/dev/null || true
 if aws secretsmanager create-secret --name "${awsSecretName}" --secret-string "atlas api-keys goes here"; then
 	echo "aws secret created with name : ${awsSecretName}"
 else

--- a/cfn-resources/api-key/test/contract-testing/cfn-test-create-inputs.sh
+++ b/cfn-resources/api-key/test/contract-testing/cfn-test-create-inputs.sh
@@ -9,6 +9,6 @@ set -o nounset
 set -o pipefail
 
 # setting projectName
-projectName="ct-api-key-$(date +%s)-$RANDOM"
+projectName="ct-api-key-$(date +%s | tail -c 5)${RANDOM}"
 
 ./test/cfn-test-create-inputs.sh "$projectName"

--- a/cfn-resources/api-key/test/contract-testing/cfn-test-create-inputs.sh
+++ b/cfn-resources/api-key/test/contract-testing/cfn-test-create-inputs.sh
@@ -9,6 +9,6 @@ set -o nounset
 set -o pipefail
 
 # setting projectName
-projectName="cfn-bot-apikey-test-$(date +%s)-$RANDOM"
+projectName="ct-api-key-$(date +%s)-$RANDOM"
 
 ./test/cfn-test-create-inputs.sh "$projectName"


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-343669

Fix the `api-key` contract test failure: `ResourceExistsException: secret cfn-bot-apikey-test-1 already exists`.

The project name `cfn-bot-apikey-test-$(date +%s)-$RANDOM` is truncated to 21 characters. The old prefix `cfn-bot-apikey-test-` is 20 chars, leaving only 1 char for the timestamp (always `1`) — and the `$RANDOM` portion was completely truncated. Every run produced the same secret name `mongodb/atlas/apikey/cfn-bot-apikey-test-1`. If cleanup was skipped, the next run hits `ResourceExistsException`.

Two fixes:
- Shortened the prefix to `ct-api-key-` (11 chars, `ct-` prefix per CLOUDP-299242), changed to `$(date +%s | tail -c 5)${RANDOM}` so both the timestamp suffix and the random value survive the 21-char truncation and contribute to uniqueness.
- Added a pre-cleanup step that silently deletes the AWS secret before creating it so any leftover from a previous failed run does not block the next one.

Link to any related issue(s): CLOUDP-343669


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fix` and verified my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments