### PR TITLE
fix: Fix federated-database-instance contract test failures

### DIFF
--- a/cfn-resources/federated-database-instance/cmd/resource/resource.go
+++ b/cfn-resources/federated-database-instance/cmd/resource/resource.go
@@ -132,7 +132,9 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	}
 
 	updateFederatedDatabaseAPIRequest := client.Atlas20231115014.DataFederationApi.UpdateFederatedDatabase(context.Background(), *currentModel.ProjectId, *currentModel.TenantName, &dataLakeTenantInput)
-	updateFederatedDatabaseAPIRequest = updateFederatedDatabaseAPIRequest.SkipRoleValidation(*currentModel.SkipRoleValidation)
+	if currentModel.SkipRoleValidation != nil {
+		updateFederatedDatabaseAPIRequest = updateFederatedDatabaseAPIRequest.SkipRoleValidation(*currentModel.SkipRoleValidation)
+	}
 	dataLakeTenant, response, err := updateFederatedDatabaseAPIRequest.Execute()
 
 	if err != nil {

--- a/cfn-resources/federated-database-instance/cmd/resource/resource.go
+++ b/cfn-resources/federated-database-instance/cmd/resource/resource.go
@@ -16,16 +16,12 @@ package resource
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 
 	"github.com/aws-cloudformation/cloudformation-cli-go-plugin/cfn/handler"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/profile"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/constants"
-	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/logger"
 	progress_events "github.com/mongodb/mongodbatlas-cloudformation-resources/util/progressevent"
 	"github.com/mongodb/mongodbatlas-cloudformation-resources/util/validator"
 	admin20231115014 "go.mongodb.org/atlas-sdk/v20231115014/admin"
@@ -36,14 +32,6 @@ var ReadRequiredFields = []string{constants.ProjectID, constants.TenantName}
 var UpdateRequiredFields = []string{constants.ProjectID, constants.TenantName}
 var DeleteRequiredFields = []string{constants.ProjectID, constants.TenantName}
 var ListRequiredFields = []string{constants.ProjectID}
-
-const (
-	CREATE = "CREATE"
-	READ   = "READ"
-	UPDATE = "UPDATE"
-	DELETE = "DELETE"
-	LIST   = "LIST"
-)
 
 func setup() {
 	util.SetupLogger("mongodb-atlas-data-federation")
@@ -76,7 +64,7 @@ func Create(req handler.Request, prevModel *Model, currentModel *Model) (handler
 		}).Execute()
 
 	if err != nil {
-		return handleError(response, CREATE, err)
+		return progress_events.GetFailedEventByResponse(err.Error(), response), nil
 	}
 	readModel := Model{ProjectId: currentModel.ProjectId, TenantName: currentModel.TenantName, Profile: currentModel.Profile}
 	readModel.getDataLakeTenant(*dataLakeTenant)
@@ -108,7 +96,7 @@ func Read(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	dataLakeTenant, response, err := client.Atlas20231115014.DataFederationApi.GetFederatedDatabase(context.Background(), *currentModel.ProjectId, *currentModel.TenantName).Execute()
 
 	if err != nil {
-		return handleError(response, READ, err)
+		return progress_events.GetFailedEventByResponse(err.Error(), response), nil
 	}
 	currentModel.getDataLakeTenant(*dataLakeTenant)
 
@@ -140,7 +128,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 
 	_, checkExistsResponse, checkExistsErr := client.Atlas20231115014.DataFederationApi.GetFederatedDatabase(context.Background(), *currentModel.ProjectId, *currentModel.TenantName).Execute()
 	if checkExistsErr != nil {
-		return handleError(checkExistsResponse, UPDATE, checkExistsErr)
+		return progress_events.GetFailedEventByResponse(checkExistsErr.Error(), checkExistsResponse), nil
 	}
 
 	updateFederatedDatabaseAPIRequest := client.Atlas20231115014.DataFederationApi.UpdateFederatedDatabase(context.Background(), *currentModel.ProjectId, *currentModel.TenantName, &dataLakeTenantInput)
@@ -148,7 +136,7 @@ func Update(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	dataLakeTenant, response, err := updateFederatedDatabaseAPIRequest.Execute()
 
 	if err != nil {
-		return handleError(response, UPDATE, err)
+		return progress_events.GetFailedEventByResponse(err.Error(), response), nil
 	}
 	readModel := Model{ProjectId: currentModel.ProjectId, TenantName: currentModel.TenantName, Profile: currentModel.Profile}
 	readModel.getDataLakeTenant(*dataLakeTenant)
@@ -180,7 +168,7 @@ func Delete(req handler.Request, prevModel *Model, currentModel *Model) (handler
 	_, response, err := client.Atlas20231115014.DataFederationApi.DeleteFederatedDatabase(context.Background(), *currentModel.ProjectId, *currentModel.TenantName).Execute()
 
 	if err != nil {
-		return handleError(response, DELETE, err)
+		return progress_events.GetFailedEventByResponse(err.Error(), response), nil
 	}
 
 	return handler.ProgressEvent{
@@ -210,7 +198,7 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 	dataLakeTenants, response, err := client.Atlas20231115014.DataFederationApi.ListFederatedDatabases(context.Background(), *currentModel.ProjectId).Execute()
 
 	if err != nil {
-		return handleError(response, LIST, err)
+		return progress_events.GetFailedEventByResponse(err.Error(), response), nil
 	}
 	tenants := make([]any, 0)
 	for i := range dataLakeTenants {
@@ -223,25 +211,6 @@ func List(req handler.Request, prevModel *Model, currentModel *Model) (handler.P
 		OperationStatus: handler.Success,
 		Message:         "List Completed",
 		ResourceModels:  tenants}, nil
-}
-
-func handleError(response *http.Response, method string, err error) (handler.ProgressEvent, error) {
-	_, _ = logger.Warnf("%s failed, error: %s", method, err.Error())
-	if response.StatusCode == http.StatusConflict {
-		return handler.ProgressEvent{
-			OperationStatus:  handler.Failed,
-			Message:          fmt.Sprintf("%s:%s", method, err.Error()),
-			HandlerErrorCode: string(types.HandlerErrorCodeAlreadyExists)}, nil
-	}
-	if response.StatusCode == http.StatusNotFound {
-		return handler.ProgressEvent{
-			OperationStatus:  handler.Failed,
-			Message:          fmt.Sprintf("%s:%s", method, err.Error()),
-			HandlerErrorCode: string(types.HandlerErrorCodeNotFound)}, nil
-	}
-
-	return progress_events.GetFailedEventByResponse(fmt.Sprintf("Error during execution : %s", err.Error()),
-		response), nil
 }
 
 func (model *Model) setDataLakeTenant() (dataLakeTenant admin20231115014.DataLakeTenant) {

--- a/cfn-resources/federated-database-instance/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/federated-database-instance/test/cfn-test-create-inputs.sh
@@ -18,11 +18,13 @@
 # This tool generates json files in the inputs/ for `cfn test`.
 #
 
+set -o errexit
 set -o nounset
 set -o pipefail
 
 function usage {
 	echo "usage:$0 <project_name>"
+	exit 1
 }
 
 if [ "$#" -ne 1 ]; then usage; fi
@@ -61,7 +63,7 @@ echo "$keyRegion"
 
 echo -e "--------------------------------create aws bucket document starts ----------------------------\n"
 bucketName="mongodb-atlas-cfn-test-df-${keyRegion}"
-aws s3 rb "s3://${bucketName}" --force
+aws s3 rb "s3://${bucketName}" --force 2>/dev/null || true
 aws s3 mb "s3://${bucketName}" --output json
 echo -e "--------------------------------create aws bucket document  ends ----------------------------\n"
 

--- a/cfn-resources/federated-database-instance/test/inputs_1_update.template.json
+++ b/cfn-resources/federated-database-instance/test/inputs_1_update.template.json
@@ -17,5 +17,5 @@
       }
     ]
   },
-  "SkipRoleValidation": "true"
+  "SkipRoleValidation": true
 }


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ CLOUDP-343669

Fix `federated-database-instance` contract test: all CRUDL handlers fail with `AssertionError: status should be SUCCESS`.

Three root causes:

**Silent setup failures:** `cfn-test-create-inputs.sh` lacked `set -o errexit`. If the Atlas cloud-provider access role creation or any AWS IAM step failed, `roleID` became empty, input files got garbage values, and every test failed. Added `set -o errexit`; added `|| true` to `aws s3 rb` which is expected to fail on first run when the bucket does not exist yet.

**Boolean/string type mismatch:** `inputs_1_update.template.json` had `"SkipRoleValidation": "true"` (string) but the model field is `*bool`. The CFN framework failed to unmarshal it, causing Update to fail unconditionally. Fixed to `true`.

**Nil-unsafe error handler and nil dereference:** `handleError` accessed `response.StatusCode` without a nil check; replaced with `progressevent.GetFailedEventByResponse` at each call site. Also added a nil guard before dereferencing `SkipRoleValidation` in the Update handler — the field is optional and could be absent from the CFN state.

Link to any related issue(s): CLOUDP-343669


## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fix` and verified my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments