### PR TITLE
fix: Avoid OperationAborted race when recreating S3 test bucket

### DIFF
--- a/cfn-resources/federated-database-instance/test/cfn-test-create-inputs.sh
+++ b/cfn-resources/federated-database-instance/test/cfn-test-create-inputs.sh
@@ -63,8 +63,7 @@ echo "$keyRegion"
 
 echo -e "--------------------------------create aws bucket document starts ----------------------------\n"
 bucketName="mongodb-atlas-cfn-test-df-${keyRegion}"
-aws s3 rb "s3://${bucketName}" --force 2>/dev/null || true
-aws s3 mb "s3://${bucketName}" --output json
+aws s3api head-bucket --bucket "${bucketName}" 2>/dev/null || aws s3 mb "s3://${bucketName}" --output json
 echo -e "--------------------------------create aws bucket document  ends ----------------------------\n"
 
 roleID=$(atlas cloudProviders accessRoles aws create --projectId "${projectId}" --output json | jq -r '.roleId')


### PR DESCRIPTION
## Proposed changes

Follow-up to [#1665](https://github.com/mongodb/mongodbatlas-cloudformation-resources/pull/1665).

The delete-then-recreate pattern (`aws s3 rb` + `aws s3 mb`) introduced in #1665 caused an `OperationAborted` error in the [release GHA run](https://github.com/mongodb/mongodbatlas-cloudformation-resources/actions/runs/26876205211/job/79264019256) for `eu-west-1`: when `aws s3 rb` succeeded and `aws s3 mb` immediately followed, AWS S3 returned `OperationAborted` because the bucket deletion had not fully propagated.

Replace with create-if-not-exists: `aws s3api head-bucket` checks whether the bucket already exists; if not, `aws s3 mb` creates it. No deletion, no race.

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [x] I have added any necessary documentation (if appropriate)
- [x] I have run `make fix` and verified my code
- [x] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments