### PR TITLE
chore: Add explicit permissions to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,10 @@ on:
         type: number
         default: 15
         required: true
-  
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     env:


### PR DESCRIPTION
## Proposed changes

Addresses the 2 open CodeQL `actions/missing-workflow-permissions` alerts ([code scanning](https://github.com/mongodb/mongodbatlas-cloudformation-resources/security/code-scanning?query=is%3Aopen)) by adding an explicit workflow-level `permissions: contents: read` block to `publish.yaml`. Neither job writes with the workflow `GITHUB_TOKEN`: publishing uses AWS/Atlas credentials, and the compliance job pushes the SSDLC report via the APIx bot PAT.

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fix` and verified my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas

## Further comments
