### PR TITLE
chore: Ignores cfn-lint W2531 warning for deprecated provided.al2 runtime

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -5,8 +5,8 @@
 # CloudFormation Go plugin generates. cfn-lint exits non-zero on warnings, so
 # this fails the `cfn-lint` job on every PR.
 #
-# Migrating the handlers to `provided.al2023` is tracked separately. Per
-# cfn-lint's runtime lifecycle data, Lambda blocks function creation on
-# `provided.al2` on 2027-02-01, so the migration needs to land before then.
+# Migrating the handlers to `provided.al2023` is tracked in CLOUDP-433207, which
+# also removes this ignore. Per cfn-lint's runtime lifecycle data, Lambda blocks
+# function creation on `provided.al2` on 2027-02-01, so it must land before then.
 ignore_checks:
   - W2531

--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -1,0 +1,12 @@
+# cfn-lint configuration
+#
+# W2531: the Lambda runtime `provided.al2` was deprecated on 2026-07-31. Every
+# resource handler template declares it because that is the runtime the
+# CloudFormation Go plugin generates. cfn-lint exits non-zero on warnings, so
+# this fails the `cfn-lint` job on every PR.
+#
+# Migrating the handlers to `provided.al2023` is tracked separately. Per
+# cfn-lint's runtime lifecycle data, Lambda blocks function creation on
+# `provided.al2` on 2027-02-01, so the migration needs to land before then.
+ignore_checks:
+  - W2531

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ update.json
 !/.gitignore
 !*.rpdk-config
 !.mockery.yaml
+!.cfnlintrc.yaml
 .taskcat_overrides.yml
 **/makebuild
 **/functions/packages


### PR DESCRIPTION
## Proposed changes

_Jira ticket:_ N/A, follow-up tracked in CLOUDP-433207

The `cfn-lint` job fails on every PR regardless of its contents, for example #1690.

The job installs cfn-lint unpinned (`cfn-lint[full]==1.*`). As of 1.53.3 its runtime lifecycle data marks `provided.al2` as deprecated (2026-07-31). All 58 `cfn-resources/*/template.yml` files declare that runtime, so the run emits 116 `W2531` warnings and exits 4.

This ignores `W2531` in a root `.cfnlintrc.yaml`. The `.gitignore` negation is needed because the repo ignores `**/.*`, following the existing `.mockery.yaml` entry.

Migrating the handlers to `provided.al2023` is the real fix and is tracked in CLOUDP-433207, which also removes this ignore. Lambda blocks function creation on `provided.al2` on 2027-02-01, so it needs to land before then.

Verified with cfn-lint 1.53.3, the version CI installs: 116 findings and exit 4 without the config, exit 0 with it.

Link to any related issue(s): #1690

## Type of change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)
- [ ] This change requires a documentation update
- [ ] If changes include removal or addition of 3rd party GitHub actions, I updated our internal document. Reach out to the APIx Integration slack channel to get access to the internal document.

## Manual QA performed:

- [ ] cfn invoke for each of CRUDL/cfn test
- [ ] Updated resource in  [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples)
- [ ] Published to AWS private registry
- [ ] Used the template in [example](https://github.com/mongodb/mongodbatlas-cloudformation-resources/tree/master/examples) to create and update a stack in AWS
- [ ] Deleted stack to ensure resources are deleted
- [ ] Created multiple resources in same stack
- [ ] Validated in Atlas UI
- [ ] Included screenshots

## Required Checklist:

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that this change does not generate any credentials and that **they are NOT accidentally logged anywhere**.
- [ ] I have added any necessary documentation (if appropriate)
- [ ] I have run `make fix` and verified my code
- [ ] For CFN Resources: I have released by changes in the private registry and proved by change
  works in Atlas
