### PR TITLE
chore: Migrate SilkBomb workflows to ECR

### DIFF
--- a/.github/workflows/code-health.yaml
+++ b/.github/workflows/code-health.yaml
@@ -9,29 +9,6 @@ permissions:
   contents: read
 
 jobs:
-  # TEMPORARY: validates ECR access for SilkBomb, remove before merge.
-  silkbomb-ecr-access:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    env:
-      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
-      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
-      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
-    steps:
-      - name: Configure AWS credentials for DevProd Platforms ECR
-        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
-        with:
-          role-to-assume: ${{ env.ECR_ROLE_ARN }}
-          aws-region: us-east-1
-      - name: Authenticate Docker to DevProd Platforms ECR
-        run: |
-          aws ecr get-login-password --region us-east-1 |
-            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
-          docker pull "${SILKBOMB_IMG}"
-      - name: Verify SilkBomb image is executable
-        run: docker run --rm "${SILKBOMB_IMG}" --help
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/code-health.yaml
+++ b/.github/workflows/code-health.yaml
@@ -9,6 +9,29 @@ permissions:
   contents: read
 
 jobs:
+  # TEMPORARY: validates ECR access for SilkBomb, remove before merge.
+  silkbomb-ecr-access:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
+      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
+    steps:
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
+      - name: Verify SilkBomb image is executable
+        run: docker run --rm "${SILKBOMB_IMG}" --help
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generate-augmented-sbom.yml
+++ b/.github/workflows/generate-augmented-sbom.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
       KONDUKTO_TOKEN: ${{ secrets.KONDUKTO_TOKEN }}
       KONDUKTO_REPO: ${{ vars.KONDUKTO_REPO }}
       KONDUKTO_BRANCH_PREFIX: ${{ vars.KONDUKTO_BRANCH_PREFIX }}
@@ -29,6 +31,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -111,12 +111,29 @@ jobs:
   compliance:
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+      ECR_ROLE_ARN: ${{ vars.ECR_ROLE_ARN }}
+      SILKBOMB_IMG: ${{ vars.SILKBOMB_IMG }}
     steps:
       - name: terraform-provider-mongodbatlas-checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: mongodb/terraform-provider-mongodbatlas
           ref: master
+      - name: Configure AWS credentials for DevProd Platforms ECR
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c
+        with:
+          role-to-assume: ${{ env.ECR_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Authenticate Docker to DevProd Platforms ECR
+        run: |
+          aws ecr get-login-password --region us-east-1 |
+            docker login --username AWS --password-stdin "${ECR_REGISTRY}"
+          docker pull "${SILKBOMB_IMG}"
       - name: Generate SSDLC report
         uses: mongodb/terraform-provider-mongodbatlas/.github/templates/run-script-and-commit@master
         with:


### PR DESCRIPTION
## Summary
- The Artifactory-hosted SilkBomb registry is retired and `artifactory.corp.mongodb.com`'s TLS certificate expired, so `docker pull $SILKBOMB_IMG` fails. This broke the terraform-provider release ([example](https://github.com/mongodb/terraform-provider-mongodbatlas/actions/runs/31710003862/job/94486457829)); this repo has the same setup and would fail on its next resource publish.
- Authenticate to the DevProd Platforms ECR registry via the shared read-only OIDC role before pulling SilkBomb, in `publish.yaml` (`compliance` job) and `generate-augmented-sbom.yml`. The `compliance` job runs SilkBomb through the shared `run-script-and-commit` template, which checks out this repo and runs the script here, so the ECR login belongs in this job — the template needs no change.
- Mirrors https://github.com/mongodb/atlas-sdk-go/pull/840 and https://github.com/mongodb/terraform-provider-mongodbatlas/pull/4641.
- Repository variables `ECR_REGISTRY` and `ECR_ROLE_ARN` added, `SILKBOMB_IMG` repointed to the digest-pinned ECR image.

## Testing
- `actionlint` on all modified workflows.
- Temporary `silkbomb-ecr-access` job in `code-health.yaml` verifies role assumption, ECR login, image pull and `silkbomb --help`. **Removed before merge.**